### PR TITLE
feat: pìpes fully functional for infile and outfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/08/01 15:11:43 by pmarkaid          #+#    #+#              #
-#    Updated: 2024/08/09 22:29:04 by pmarkaid         ###   ########.fr        #
+#    Updated: 2024/08/10 13:08:09 by pmarkaid         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -28,7 +28,8 @@ SRCS_FILES = \
 	bu_func.c 	\
 	validation.c \
 	execution.c \
-	execution_utils.c
+	execution_utils.c \
+	error.c
 
 SRC_DIR = src/
 SRCS = $(addprefix $(SRC_DIR), $(SRCS_FILES))

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/09 22:14:38 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/10 13:07:56 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,25 +14,25 @@
 # define MINISHELL_H
 
 # include "../lib/libft/libft.h" /* libft library */
-# include <limits.h>             /* for LONG_MAX, LONG_MIN */
+# include <curses.h>             // tgetent, tgetflag, tgetnum, tgetstr, tgoto, tputs
+# include <dirent.h>             // opendir, readdir, closedir
 # include <errno.h>              /* for errno */
-# include <stdbool.h>			 /* for true and false*/
-# include <stdio.h>      // printf, perror
-# include <stdlib.h>     // malloc, free, exit, getenv
-# include <unistd.h>     // read, write, access, open, close, fork, getcwd, chdir, unlink, execve, dup, dup2, pipe, isatty, ttyname, ttyslot
-# include <fcntl.h>      // open
-# include <sys/types.h>  // fork, wait, waitpid, wait3, wait4, stat, lstat, fstat
-# include <sys/wait.h>   // wait, waitpid, wait3, wait4
-# include <sys/stat.h>   // stat, lstat, fstat
-# include <signal.h>     // signal, sigaction, sigemptyset, sigaddset, kill
-# include <dirent.h>     // opendir, readdir, closedir
-# include <string.h>     // strerror
-# include <termios.h>    // tcsetattr, tcgetattr
-# include <curses.h>     // tgetent, tgetflag, tgetnum, tgetstr, tgoto, tputs
-# include <term.h>       // tgetent, tgetflag, tgetnum, tgetstr, tgoto, tputs
-# include <sys/ioctl.h>  // ioctl
+# include <fcntl.h>              // open
+# include <limits.h>             /* for LONG_MAX, LONG_MIN */
+# include <readline/history.h>   // add_history
 # include <readline/readline.h>  // readline, rl_clear_history, rl_on_new_line, rl_replace_line, rl_redisplay
-# include <readline/history.h>  // add_history
+# include <signal.h>             // signal, sigaction, sigemptyset, sigaddset, kill
+# include <stdbool.h>            /* for true and false*/
+# include <stdio.h>              // printf, perror
+# include <stdlib.h>             // malloc, free, exit, getenv
+# include <string.h>             // strerror
+# include <sys/ioctl.h>          // ioctl
+# include <sys/stat.h>           // stat, lstat, fstat
+# include <sys/types.h>          // fork, wait, waitpid, wait3, wait4, stat, lstat, fstat
+# include <sys/wait.h>           // wait, waitpid, wait3, wait4
+# include <term.h>               // tgetent, tgetflag, tgetnum, tgetstr, tgoto,tputs
+# include <termios.h>            // tcsetattr, tcgetattr
+# include <unistd.h>             // read, write, access, open, close, fork,getcwd, chdir, unlink, execve, dup, dup2, pipe, isatty, ttyname, ttyslot
 
 # define NO_FILE 1
 # define PERMISSION_DENIED 126
@@ -61,9 +61,9 @@ typedef enum e_builtin
 	M_PWD = 2,
 	M_EXPORT = 3,
 	M_UNSET = 4,
-	M_ENV	= 5,
+	M_ENV = 5,
 	M_EXIT = 6
-}	t_builtin;
+}					t_builtin;
 
 typedef struct s_token
 {
@@ -98,7 +98,7 @@ typedef struct s_macro
 }					t_macro;
 
 /* presyntax*/
-int				syntax_error_check(char *instruction);
+int					syntax_error_check(char *instruction);
 
 /* tokenizer */
 void				tokenizer(t_macro *macro);
@@ -123,7 +123,6 @@ char				*enum_to_char(t_type type);
 bool				is_last_of_type(t_token *tokens, t_type type);
 int					tokens_size(t_token *tokens);
 
-
 /* parsing */
 t_cmd				*parsing(t_macro *macro);
 
@@ -134,33 +133,33 @@ int					execution(t_macro *macro);
 char				**build_cmd_args_array(t_token *cmd_args);
 
 /* validation */
-int			open_infile(char *infile);
-int			open_infile(char *outfile);
-void		close_open_fds(t_macro *macro);
-void		dup2_or_exit(t_macro *macro, int oldfd, int newfd);
-void		dup_file_descriptors(t_macro *macro, t_cmd *cmd, int read_end);
-
+int					open_infile(char *infile);
+int					open_infile(char *outfile);
+void				close_open_fds(t_macro *macro);
+void				dup2_or_exit(t_macro *macro, int oldfd, int newfd);
+void				dup_file_descriptors(t_macro *macro, t_cmd *cmd,
+						int read_end);
 
 /* tests */
 char				*get_envir_value(const char *str, int *len);
 size_t				expanded_envir_len(char *instruction);
 
 /* free */
-void	free_array(char ***array);
-void	free_tokens(t_token **tokens);
+void				free_array(char ***array);
+void				free_tokens(t_token **tokens);
 
 /* others */
 void				ft_signal_handler(int signum);
-void			    test_builtins(t_macro *macro);
-void    			ft_pwd(void);
-void    			ft_echo(char *line);
-void    			ft_echo_n(char *line);
-void			    ft_env(char **envp);
+void				test_builtins(t_macro *macro);
+void				ft_pwd(void);
+void				ft_echo(char *line);
+void				ft_echo_n(char *line);
+void				ft_env(char **envp);
 void				ft_export(t_macro *macro);
 void				ft_exit(t_macro *macro);
 void				ft_cd(char *line);
-char    			*char_pwd(void);
-char    			**copy_env(char **envp);
+char				*char_pwd(void);
+char				**copy_env(char **envp);
 void				ft_free_matrix(char ***m);
 int					ft_matrixlen(char **m);
 char				**ft_add_row(char **in, char *newstr);
@@ -169,5 +168,8 @@ int					ft_strchr_i(const char *s, int c);
 char				**ft_replace_matrix_row(char ***big, char **small, int n);
 void				ft_unset(t_macro *macro);
 int					var_in_env(char *argv, char **env, int ij[2]);
+
+/* error */
+int					error_msg(char *msg, int exit_code);
 
 #endif /* MINISHELL_H */

--- a/src/bu_func.c
+++ b/src/bu_func.c
@@ -12,30 +12,29 @@
 
 #include "minishell.h"
 
-void    test_builtins(t_macro *macro)
+void	test_builtins(t_macro *macro)
 {
-    char *line;
+	char	*line;
 
-    //printf("-------OUTPUT DE MINISHELL (CD IMPRIME DIRECTORIO ACTUAL)----------\n");
-    line = macro->instruction;
-    if (ft_strncmp(line, "pwd", 3) == 0)
-        ft_pwd();
-    else if (ft_strncmp(line, "cd", 2) == 0)
-        ft_cd(line);
-    else if (ft_strncmp(line, "echo -n", 7) == 0)
-        ft_echo_n(line);
-    else if (ft_strncmp(line, "echo", 4) == 0)
-        ft_echo(line);
-    else if (ft_strncmp(line, "exit", 4) == 0)
-        ft_exit(macro);
-    else if (ft_strncmp(line, "env", 3) == 0)
-        ft_env(macro->env);
-    else if (ft_strncmp(line, "export", 6) == 0)
-        ft_export(macro);
-    else if (ft_strncmp(line, "unset", 5) == 0)
-        ft_unset(macro);
-    else
-        //ft_putendl_fd("Not builtin", STDOUT_FILENO);
-        return ;
-   
+	// printf("-------OUTPUT DE MINISHELL (CD IMPRIME DIRECTORIO ACTUAL)----------\n");
+	line = macro->instruction;
+	if (ft_strncmp(line, "pwd", 3) == 0)
+		ft_pwd();
+	else if (ft_strncmp(line, "cd", 2) == 0)
+		ft_cd(line);
+	else if (ft_strncmp(line, "echo -n", 7) == 0)
+		ft_echo_n(line);
+	else if (ft_strncmp(line, "echo", 4) == 0)
+		ft_echo(line);
+	else if (ft_strncmp(line, "exit", 4) == 0)
+		ft_exit(macro);
+	else if (ft_strncmp(line, "env", 3) == 0)
+		ft_env(macro->env);
+	else if (ft_strncmp(line, "export", 6) == 0)
+		ft_export(macro);
+	else if (ft_strncmp(line, "unset", 5) == 0)
+		ft_unset(macro);
+	else
+		// ft_putendl_fd("Not builtin", STDOUT_FILENO);
+		return ;
 }

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -3,137 +3,135 @@
 /*                                                        :::      ::::::::   */
 /*   builtins.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/06 14:24:52 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/08/09 14:26:51 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/10 13:06:44 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-//si gestionamos g_state, esta funcion deberia retornar un int
+// si gestionamos g_state, esta funcion deberia retornar un int
 
-void    ft_pwd(void) 
+void	ft_pwd(void)
 {
-    char *path;
+	char	*path;
 
-    path = getcwd(NULL, 0);
-    if (path == NULL)
-    {
-        perror("Error getting current directory");
-    }
-    else
-    {
-        ft_putendl_fd(path, STDOUT_FILENO);
-        free(path);
-    }
-    return ;
+	path = getcwd(NULL, 0);
+	if (path == NULL)
+	{
+		perror("Error getting current directory");
+	}
+	else
+	{
+		ft_putendl_fd(path, STDOUT_FILENO);
+		free(path);
+	}
+	return ;
 }
 
-char    *char_pwd(void) 
+char	*char_pwd(void)
 {
-    char *path;
+	char	*path;
 
-    path = getcwd(NULL, 0);
-    if (path == NULL)
-    {
-        perror("Error getting current directory");
-    }
-    return (path);
+	path = getcwd(NULL, 0);
+	if (path == NULL)
+	{
+		perror("Error getting current directory");
+	}
+	return (path);
 }
 
-void    ft_echo(char *line)
+void	ft_echo(char *line)
 {
-    int i;
+	int	i;
 
-    i = 4;
-    while (line[i] == ' ')
-        i++;
-    while (line[i])
-    {
-        ft_putchar_fd(line[i], STDOUT_FILENO);
-        i++;
-    }
-    ft_putchar_fd('\n', STDOUT_FILENO);
+	i = 4;
+	while (line[i] == ' ')
+		i++;
+	while (line[i])
+	{
+		ft_putchar_fd(line[i], STDOUT_FILENO);
+		i++;
+	}
+	ft_putchar_fd('\n', STDOUT_FILENO);
 }
 
-void    ft_echo_n(char *line)
+void	ft_echo_n(char *line)
 {
-    int i;
+	int	i;
 
-    i = 7;
-    while (line[i] == ' ')
-        i++;
-    while (line[i])
-    {
-        ft_putchar_fd(line[i], STDOUT_FILENO);
-        i++;
-    }
+	i = 7;
+	while (line[i] == ' ')
+		i++;
+	while (line[i])
+	{
+		ft_putchar_fd(line[i], STDOUT_FILENO);
+		i++;
+	}
 }
 
-void    ft_env(char **env)
+void	ft_env(char **env)
 {
-    int i;
+	int	i;
 
-    i = 0;
-    while (env[i])
-    {
-        ft_putendl_fd(env[i], STDOUT_FILENO);
-        i++;
-    }
+	i = 0;
+	while (env[i])
+	{
+		ft_putendl_fd(env[i], STDOUT_FILENO);
+		i++;
+	}
 }
 
-void    ft_exit(t_macro *macro)
+void	ft_exit(t_macro *macro)
 {
-    free(macro); //FREE GENERAL y muchas más cosas a tener en cuenta: posición del exit, etc
-    printf("exit\n");
-    //ir al padre y hacer un waitpid
-    //Dejar exit para el final 
-    exit(0);
+	free(macro);
+	// FREE GENERAL y muchas más cosas a tener en cuenta: posición del exit,etc
+	printf("exit\n");
+	// ir al padre y hacer un waitpid
+	// Dejar exit para el final
+	exit(0);
 }
 
-void ft_export(t_macro *macro)
+void	ft_export(t_macro *macro)
 {
-    char    *var;
-    char    *name;
-    char    *value;
-    char    *equal_sign;
+	char	*var;
+	char	*name;
+	char	*value;
+	char	*equal_sign;
 
-    var = macro->instruction + 7;
-    while (*var == ' ')
-        var++;
-    equal_sign = ft_strchr(var, '=');
-    if (equal_sign == NULL)
-    {
-        ft_putendl_fd("export: not a valid identifier", STDERR_FILENO);
-        return;
-    }
-    *equal_sign = '\0';
-    name = var;
-    value = equal_sign + 1;
-    if (setenv(name, value, 1) != 0)
-    {
-        //lanzar error
-        ft_putendl_fd("export: error setting environment variable", STDERR_FILENO);
-    }
-    ft_export_do(macro, name, value);
+	var = macro->instruction + 7;
+	while (*var == ' ')
+		var++;
+	equal_sign = ft_strchr(var, '=');
+	if (equal_sign == NULL)
+	{
+		ft_putendl_fd("export: not a valid identifier", STDERR_FILENO);
+		return ;
+	}
+	*equal_sign = '\0';
+	name = var;
+	value = equal_sign + 1;
+	if (setenv(name, value, 1) != 0)
+		ft_putendl_fd("export: error setting environment variable", STDERR_FILENO);
+	ft_export_do(macro, name, value);
 }
 
-void    ft_cd(char *line)
+void	ft_cd(char *line)
 {
-    char *path;
-    int ret;
+	char	*path;
+	int		ret;
 
-    path = line + 3;
-    while (*path == ' ')
-        path++;
-    ret = chdir(path);
-    if (ret == -1)
-    {
-        perror("Error changing directory");
-    }
-    //printf("**Esto no es output**\nCheck de directorio actual: %s\n", char_pwd());
+	path = line + 3;
+	while (*path == ' ')
+		path++;
+	ret = chdir(path);
+	if (ret == -1)
+	{
+		perror("Error changing directory");
+	}
+	// printf("**Esto no es output**\nCheck de directorio actual: %s\n", char_pwd());
 }
 
 void	ft_unset(t_macro *macro)
@@ -143,7 +141,7 @@ void	ft_unset(t_macro *macro)
 
 	ij[0] = 0;
 	var = macro->instruction + 6;
-    var = ft_strjoin(var, "=0", 0);
-    if (var_in_env(var, macro->env, ij))
-        ft_replace_matrix_row(&macro->env, NULL, ij[1]);
+	var = ft_strjoin(var, "=0", 0);
+	if (var_in_env(var, macro->env, ij))
+		ft_replace_matrix_row(&macro->env, NULL, ij[1]);
 }

--- a/src/env.c
+++ b/src/env.c
@@ -53,18 +53,17 @@ void	ft_export_do(t_macro *macro, char *name, char *value)
 {
 	int		ij[2];
 	int		pos;
-    char    *cmd;
+	char	*cmd;
 
-    cmd = ft_strjoin(name, "=", 0);
-    cmd = ft_strjoin(cmd, value, 0);
-    ij[0] = 1;
-    pos = var_in_env(cmd, macro->env, ij);
-    if (pos == 1)
-    {
-        free(macro->env[ij[1]]);
-        macro->env[ij[1]] = ft_strdup(cmd);
-    }
-    if (pos != 1)
-        macro->env = ft_add_row(macro->env, cmd);
+	cmd = ft_strjoin(name, "=", 0);
+	cmd = ft_strjoin(cmd, value, 0);
+	ij[0] = 1;
+	pos = var_in_env(cmd, macro->env, ij);
+	if (pos == 1)
+	{
+		free(macro->env[ij[1]]);
+		macro->env[ij[1]] = ft_strdup(cmd);
+	}
+	if (pos != 1)
+		macro->env = ft_add_row(macro->env, cmd);
 }
-

--- a/src/error.c
+++ b/src/error.c
@@ -1,25 +1,20 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   signals.c                                          :+:      :+:    :+:   */
+/*   error.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/08/09 14:18:46 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/08/09 23:05:44 by pmarkaid         ###   ########.fr       */
+/*   Created: 2024/08/10 13:00:20 by pmarkaid          #+#    #+#             */
+/*   Updated: 2024/08/10 13:00:41 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-void	ft_signal_handler(int sig)
+int	error_msg(char *msg, int exit_code)
 {
-	if (sig == SIGINT)
-	{
-		// Print a new line and re-display the prompt
-		printf("\n");
-		rl_on_new_line();
-		rl_replace_line("", 0);
-		rl_redisplay();
-	}
+	ft_putstr_fd("pipex: ", 2);
+	ft_putstr_fd(msg, 2);
+	return (exit_code);
 }

--- a/src/execution.c
+++ b/src/execution.c
@@ -6,18 +6,11 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:23:53 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/10 00:39:19 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/10 13:09:48 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-
-int	error_msg(char *msg, int exit_code)
-{
-	ft_putstr_fd("pipex: ", 2);
-	ft_putstr_fd(msg, 2);
-	return (exit_code);
-}
 
 static int	get_exit_code(int status)
 {
@@ -51,28 +44,27 @@ static int	wait_processes(pid_t *pid, int cmds)
 
 static void	execute_child_process(t_macro *macro, int index, int read_end)
 {
-	int i;
-	t_cmd *cmd;
-	char **cmd_array;
+	int		i;
+	t_cmd	*cmd;
+	char	**cmd_array;
 
 	cmd = macro->cmds;
 	i = 0;
 	while (cmd != NULL && i < index)
-    {
-        cmd = cmd->next;
-        i++;
-    }
-	cmd_array = build_cmd_args_array(cmd->cmd_arg); // handle NULL return
+	{
+		cmd = cmd->next;
+		i++;
+	}
+	cmd_array = build_cmd_args_array(cmd->cmd_arg); // handle NULL return 
 	dup_file_descriptors(macro, cmd, read_end);
-	//eval_executable(macro, macro->cmds[i][0]);
+	// eval_executable(macro, macro->cmds[i][0]);
 	if (execve(cmd_array[0], cmd_array, macro->env) == -1)
 	{
-		ft_putstr_fd("execve failed\n",2);
+		ft_putstr_fd("execve failed\n", 2);
 		// free_data(macro);
 		// exit(EXIT_FAILURE);
 	}
-	exit(0);
-	
+	exit(1);
 }
 
 static int	execute_cmds(t_macro *macro, int read_end)
@@ -103,19 +95,17 @@ static int	execute_cmds(t_macro *macro, int read_end)
 	return (i);
 }
 
-int execution(t_macro *macro)
+int	execution(t_macro *macro)
 {
-    int exit_code;
-    int read_end;
-    int num_cmds_executed;
-    pid_t pid;
+	int		exit_code;
+	int		read_end;
+	int		num_cmds_executed;
+	pid_t	pid;
 
 	read_end = 0;
 	macro->pid = malloc(sizeof(pid_t) * macro->num_cmds);
 	num_cmds_executed = execute_cmds(macro, read_end);
 	exit_code = wait_processes(macro->pid, num_cmds_executed);
-    //close(read_end);
-    //close_open_fds(macro);
-    free(macro->pid);
-    return (exit_code);
+	free(macro->pid);
+	return (exit_code);
 }

--- a/src/execution_utils.c
+++ b/src/execution_utils.c
@@ -12,11 +12,11 @@
 
 #include "minishell.h"
 
-char **build_cmd_args_array(t_token *cmd_args)
+char	**build_cmd_args_array(t_token *cmd_args)
 {
-	char **cmd_array;
-	t_token *tmp;
-	int i;
+	char	**cmd_array;
+	t_token	*tmp;
+	int		i;
 
 	tmp = cmd_args;
 	cmd_array = (char **)malloc(sizeof(char *) * (tokens_size(cmd_args) + 1));

--- a/src/list_utils.c
+++ b/src/list_utils.c
@@ -72,16 +72,18 @@ t_cmd	*last_cmd(t_cmd *cmd)
 	return (cmd);
 }
 
-bool is_last_of_type(t_token *tokens, t_type type)
+bool	is_last_of_type(t_token *tokens, t_type type)
 {
-    t_token *tmp = tokens->next;
-    while (tmp)
-    {
-        if (tmp->type == type)
-            return false;
-        tmp = tmp->next;
-    }
-    return true;
+	t_token	*tmp;
+
+	tmp = tokens->next;
+	while (tmp)
+	{
+		if (tmp->type == type)
+			return (false);
+		tmp = tmp->next;
+	}
+	return (true);
 }
 
 int	tokens_size(t_token *tokens)
@@ -96,4 +98,3 @@ int	tokens_size(t_token *tokens)
 	}
 	return ((int)i);
 }
-

--- a/src/main.c
+++ b/src/main.c
@@ -45,7 +45,6 @@ int	main(int argc, char **argv, char **envp)
 	(void)argv;
 	signal(SIGINT, ft_signal_handler);
 	signal(SIGQUIT, SIG_IGN);
-
 	while (1)
 	{
 		path = getcwd(NULL, 0);
@@ -59,11 +58,11 @@ int	main(int argc, char **argv, char **envp)
 		if (line == NULL || *line == EOF)
 		{
 			printf("Ctrl+D exits");
-			break;
+			break ;
 		}
 		if (line[0] != '\0')
 			add_history(line);
-		//FALTA FUNCION AQUI PARA AÑADIR HISTORIAL EN macro->history
+		// FALTA FUNCION AQUI PARA AÑADIR HISTORIAL EN macro->history
 		if (syntax_error_check(line))
 		{
 			free(line);

--- a/src/main_utils.c
+++ b/src/main_utils.c
@@ -94,7 +94,7 @@ int	ft_matrixlen(char **matrix)
 	return (i);
 }
 
-char    **copy_env(char **envp)
+char	**copy_env(char **envp)
 {
 	char	**result;
 	int		n_rows;
@@ -116,5 +116,5 @@ char    **copy_env(char **envp)
 		i++;
 	}
 	result[i] = NULL;
-	return (result);  
+	return (result);
 }

--- a/src/parsing.c
+++ b/src/parsing.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 09:53:20 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/09 22:24:25 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/10 12:17:55 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,7 +83,8 @@ static t_cmd	*parse_tokens(t_token *tokens, int *n)
 		cmd = init_cmd();
 		if (!cmd)
 			return (NULL);
-		cmd->n = (*n)++;;
+		cmd->n = (*n)++;
+		;
 		cmd->redir = parse_redir_tokens(tmp);
 		cmd->cmd_arg = parse_cmd_arg_tokens(tmp);
 		cmd->type = cmd->cmd_arg->type;
@@ -119,21 +120,21 @@ static char	parsing_error_check(t_token *tokens)
 t_cmd	*parsing(t_macro *macro)
 {
 	char	c;
-	int 	n;
+	int		n;
 	t_cmd	*cmds;
 
-	n = 0;
+	n = 1;
 	cmds = NULL;
 	c = parsing_error_check(macro->tokens);
 	if (c != 0)
 		return (NULL);
 	else
 		cmds = parse_tokens(macro->tokens, &n);
-	if(!cmds)
-		return(NULL);
+	if (!cmds)
+		return (NULL);
 	else
 	{
-		macro->num_cmds = n;
-		return(cmds);
+		macro->num_cmds = n - 1;
+		return (cmds);
 	}
 }

--- a/src/presyntax.c
+++ b/src/presyntax.c
@@ -83,7 +83,7 @@ int	syntax_error_check(char *instruction)
 		ft_putchar_fd(c, 2);
 		ft_putstr_fd("'\n", 2);
 		return (1);
-		//exit(258);
+		// exit(258);
 	}
 	c = unclosed_quote_check(instruction);
 	if (c != 0)
@@ -92,8 +92,8 @@ int	syntax_error_check(char *instruction)
 			2);
 		ft_putchar_fd(c, 2);
 		ft_putstr_fd("'\n", 2);
-		return (1);		
-		//exit(258);
+		return (1);
+		// exit(258);
 	}
 	return (0);
 }

--- a/src/print_utils.c
+++ b/src/print_utils.c
@@ -39,10 +39,10 @@ char	*enum_to_char(t_type type)
 
 void	print_tokens(t_token *tokens)
 {
-	if(!tokens)
+	if (!tokens)
 	{
 		ft_printf("No tokens to print\n");
-		return;
+		return ;
 	}
 	ft_printf("Starting to print tokens\n");
 	while (tokens)

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/03 21:24:44 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/09 21:59:38 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/10 13:04:34 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -113,7 +113,6 @@ static char	*get_expanded_instruction(char *instruction)
 		return (NULL);
 	total_len = expanded_envir_len(instruction) + ft_strlen(instruction);
 	clean = calloc(1, sizeof(char) * total_len + 1);
-	//clean = malloc(sizeof(char) * total_len + 1); Esto mw mete basura a final del string
 	if (!clean)
 		return (NULL);
 	clean = expand_envirs(clean, instruction);
@@ -129,6 +128,6 @@ void	tokenizer(t_macro *macro)
 	macro->instruction = clean_instruction(macro->instruction);
 	lexemes = ft_split(macro->instruction, ' ');
 	macro->tokens = identify_tokens(lexemes);
-	//print_tokens(macro->tokens);
+	// print_tokens(macro->tokens);
 	free(lexemes);
 }

--- a/src/tokenizer_utils.c
+++ b/src/tokenizer_utils.c
@@ -91,7 +91,6 @@ size_t	expanded_envir_len(char *instruction)
 
 	if (!instruction)
 		return (0);
-
 	len = 0;
 	i = 0;
 	ptr = instruction;
@@ -99,8 +98,8 @@ size_t	expanded_envir_len(char *instruction)
 	{
 		if (ptr[i] == '$' && !is_inside_single_quotes(ptr, i))
 		{
-			 if (ptr[i + 1] == '\0')
-                break;
+			if (ptr[i + 1] == '\0')
+				break ;
 			envir_value = get_envir_value(&ptr[i + 1], &envir_name_len);
 			if (envir_value)
 				len += ft_strlen(envir_value);


### PR DESCRIPTION
The execution works completely, but as the validation step is not implemented yet, you have to call the function by the 
full path to make execve work.


Examples like this shall work
`/usr/bin/cat <infile >outfile1 | /usr/bin/cat >outfile2 | <outfile2 <infile /usr/bin/cat >outfile3`

‼️ NB: append is not working yet, neither here_doc

Please @dbejar-s test behaviour and provide feedback in the PR if something is not correctly handled