### PR TITLE
feat: add execution validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/08/01 15:11:43 by pmarkaid          #+#    #+#              #
-#    Updated: 2024/08/10 13:08:09 by pmarkaid         ###   ########.fr        #
+#    Updated: 2024/08/13 23:28:18 by pmarkaid         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -27,9 +27,11 @@ SRCS_FILES = \
 	signals.c 	\
 	bu_func.c 	\
 	validation.c \
+	validation_utils.c \
 	execution.c \
 	execution_utils.c \
-	error.c
+	error.c \
+	dup.c
 
 SRC_DIR = src/
 SRCS = $(addprefix $(SRC_DIR), $(SRCS_FILES))

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/10 13:07:56 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/13 13:58:15 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,7 +77,8 @@ typedef struct s_cmd
 	int				n;
 	t_type			type;
 	t_token			*cmd_arg;
-	t_token			*redir;
+	t_token			*in_redir;
+	t_token			*out_redir;
 	struct s_cmd	*next;
 }					t_cmd;
 
@@ -107,7 +108,7 @@ void				tokenizer(t_macro *macro);
 bool				is_inside_single_quotes(const char *str, int index);
 char				*expand_envirs(char *clean, char *instruction);
 bool				is_builtin(t_token *token);
-bool				is_redir(t_token *token);
+bool				is_redir(t_token *token, char *redir_type);
 
 /* list_utils */
 t_token				*init_token(void);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/13 22:58:18 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/13 23:31:14 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,25 +14,25 @@
 # define MINISHELL_H
 
 # include "../lib/libft/libft.h" /* libft library */
-# include <curses.h>             // tgetent, tgetflag, tgetnum, tgetstr, tgoto, tputs
+# include <curses.h>             // tgetent, tgetflag, tgetnum, tgetstr, tgoto,tputs
 # include <dirent.h>             // opendir, readdir, closedir
 # include <errno.h>              /* for errno */
 # include <fcntl.h>              // open
 # include <limits.h>             /* for LONG_MAX, LONG_MIN */
 # include <readline/history.h>   // add_history
-# include <readline/readline.h>  // readline, rl_clear_history, rl_on_new_line, rl_replace_line, rl_redisplay
-# include <signal.h>             // signal, sigaction, sigemptyset, sigaddset, kill
+# include <readline/readline.h>  // readline, rl_clear_history, rl_on_new_line,rl_replace_line, rl_redisplay
+# include <signal.h>             // signal, sigaction, sigemptyset, sigaddset,kill
 # include <stdbool.h>            /* for true and false*/
 # include <stdio.h>              // printf, perror
 # include <stdlib.h>             // malloc, free, exit, getenv
 # include <string.h>             // strerror
 # include <sys/ioctl.h>          // ioctl
 # include <sys/stat.h>           // stat, lstat, fstat
-# include <sys/types.h>          // fork, wait, waitpid, wait3, wait4, stat, lstat, fstat
+# include <sys/types.h>          // fork, wait, waitpid, wait3, wait4, stat,lstat, fstat
 # include <sys/wait.h>           // wait, waitpid, wait3, wait4
-# include <term.h>               // tgetent, tgetflag, tgetnum, tgetstr, tgoto,tputs
+# include <term.h>               // tgetent, tgetflag, tgetnum, tgetstr,tgoto,tputs
 # include <termios.h>            // tcsetattr, tcgetattr
-# include <unistd.h>             // read, write, access, open, close, fork,getcwd, chdir, unlink, execve, dup, dup2, pipe, isatty, ttyname, ttyslot
+# include <unistd.h>             // read, write, access, open, close,fork,getcwd, chdir, unlink, execve, dup, dup2, pipe, isatty, ttyname,ttyslot
 
 # define NO_FILE 1
 # define PERMISSION_DENIED 126
@@ -134,9 +134,15 @@ int					execution(t_macro *macro);
 char				**build_cmd_args_array(t_token *cmd_args);
 
 /* validation */
-int					open_file(t_token *token);
-void				dup_file_descriptors(t_macro *macro, t_cmd *cmd, int read_end);
 int					validate_executable(t_macro *macro, t_cmd *cmd);
+
+/* validation utils */
+bool				is_directory(const char *path);
+char				**parse_paths(char **env);
+char				*get_executable_path(t_macro *macro, char **paths, char *executable);
+
+/* dup */
+void				dup_file_descriptors(t_macro *macro, t_cmd *cmd, int read_end);
 
 /* tests */
 char				*get_envir_value(const char *str, int *len);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/13 13:58:15 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/13 22:58:18 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -134,12 +134,9 @@ int					execution(t_macro *macro);
 char				**build_cmd_args_array(t_token *cmd_args);
 
 /* validation */
-int					open_infile(char *infile);
-int					open_infile(char *outfile);
-void				close_open_fds(t_macro *macro);
-void				dup2_or_exit(t_macro *macro, int oldfd, int newfd);
-void				dup_file_descriptors(t_macro *macro, t_cmd *cmd,
-						int read_end);
+int					open_file(t_token *token);
+void				dup_file_descriptors(t_macro *macro, t_cmd *cmd, int read_end);
+int					validate_executable(t_macro *macro, t_cmd *cmd);
 
 /* tests */
 char				*get_envir_value(const char *str, int *len);

--- a/src/dup.c
+++ b/src/dup.c
@@ -1,0 +1,122 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   dup.c                                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/13 23:24:13 by pmarkaid          #+#    #+#             */
+/*   Updated: 2024/08/13 23:24:19 by pmarkaid         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static int	open_file(t_token *token)
+{
+	int	fd;
+
+	// if (macro->here_doc == 1)
+	// macro->out_fd = open(macro->outfile,O_WRONLY | O_CREAT | O_APPEND,0644);
+	// else
+	if (token->type == INRED)
+		fd = open(token->value, O_RDONLY);
+	else if (token->type == OUTRED)
+		fd = open(token->value, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	else if (token->type == APPEND)
+		fd = open(token->value, O_WRONLY | O_CREAT | O_APPEND, 0644);
+	if (errno == ENOENT)
+		return (-1);
+	if (errno == EACCES)
+		return (-1);
+	if (errno == IS_DIRECTORY)
+		return (-1);
+	return (fd);
+}
+
+static int	open_last_redir_file(t_token *redir)
+{
+	t_token	*tmp;
+	int		fd;
+	t_type	type;
+
+	tmp = redir;
+	fd = -1;
+	while (tmp)
+	{
+		if (tmp->type == HERE_DOC)
+		{
+			tmp = tmp->next;
+			continue ;
+		}
+		fd = open_file(tmp);
+		if (fd == -1)
+			break ;
+		if (tmp->next != NULL)
+		{
+			close(fd);
+			fd = -1;
+		}
+		tmp = tmp->next;
+	}
+	return (fd);
+}
+
+static void	dup_stdout(t_macro *macro, t_cmd *cmd)
+{
+	int	fd;
+
+	fd = open_last_redir_file(cmd->out_redir);
+	if (fd >= 1)
+	{
+		if (dup2(fd, STDOUT_FILENO) < 0)
+		{
+			perror("dup2 stdout");
+			close(fd);
+			return ;
+		}
+		close(fd);
+	}
+	else if (cmd->n < macro->num_cmds)
+	{
+		if (dup2(macro->pipe_fd[1], STDOUT_FILENO) < 0)
+		{
+			perror("dup2 pipe write");
+			return ;
+		}
+	}
+	close(macro->pipe_fd[1]);
+}
+
+static void	dup_stdin(t_macro *macro, t_cmd *cmd, int read_end)
+{
+	int	fd;
+
+	// add here_doc fd here if the only one
+	fd = open_last_redir_file(cmd->in_redir);
+	if (fd >= 1)
+	{
+		if (dup2(fd, STDIN_FILENO) < 0)
+		{
+			perror("dup2 stdin");
+			close(fd);
+			return ;
+		}
+		close(fd);
+	}
+	else if (cmd->n > 1)
+	{
+		if (dup2(read_end, STDIN_FILENO) < 0)
+		{
+			perror("dup2 pipe read");
+			return ;
+		}
+	}
+	close(macro->pipe_fd[0]);
+}
+
+void	dup_file_descriptors(t_macro *macro, t_cmd *cmd, int read_end)
+{
+	dup_stdout(macro, cmd);
+	dup_stdin(macro, cmd, read_end);
+}

--- a/src/error.c
+++ b/src/error.c
@@ -6,15 +6,15 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/10 13:00:20 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/10 13:00:41 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/13 23:04:32 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	error_msg(char *msg, int exit_code)
+int	error_msg(char *file, int exit_code)
 {
-	ft_putstr_fd("pipex: ", 2);
-	ft_putstr_fd(msg, 2);
+	ft_putstr_fd("minishell: ", 2);
+	perror(file);
 	return (exit_code);
 }

--- a/src/execution.c
+++ b/src/execution.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:23:53 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/10 13:09:48 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/13 23:09:07 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,6 +47,7 @@ static void	execute_child_process(t_macro *macro, int index, int read_end)
 	int		i;
 	t_cmd	*cmd;
 	char	**cmd_array;
+	int 	exit_code;
 
 	cmd = macro->cmds;
 	i = 0;
@@ -54,16 +55,14 @@ static void	execute_child_process(t_macro *macro, int index, int read_end)
 	{
 		cmd = cmd->next;
 		i++;
-	}
-	cmd_array = build_cmd_args_array(cmd->cmd_arg); // handle NULL return 
+	} 
 	dup_file_descriptors(macro, cmd, read_end);
-	// eval_executable(macro, macro->cmds[i][0]);
+	exit_code = validate_executable(macro, cmd);
+	if(!exit_code == 0)
+		return;		
+	cmd_array = build_cmd_args_array(cmd->cmd_arg); // handle NULL return
 	if (execve(cmd_array[0], cmd_array, macro->env) == -1)
-	{
 		ft_putstr_fd("execve failed\n", 2);
-		// free_data(macro);
-		// exit(EXIT_FAILURE);
-	}
 	exit(1);
 }
 

--- a/src/parsing.c
+++ b/src/parsing.c
@@ -6,13 +6,13 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 09:53:20 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/10 12:17:55 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/13 14:23:47 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static t_token	*parse_redir_tokens(t_token *tokens)
+static t_token	*parse_redir_tokens(t_token *tokens, char *redir_type)
 {
 	t_token	*tmp;
 	t_token	*token;
@@ -22,7 +22,7 @@ static t_token	*parse_redir_tokens(t_token *tokens)
 	redir = NULL;
 	while (tmp && tmp->type != PIPE)
 	{
-		if (is_redir(tmp))
+		if (is_redir(tmp, redir_type))
 		{
 			token = init_token();
 			if (!token)
@@ -84,10 +84,10 @@ static t_cmd	*parse_tokens(t_token *tokens, int *n)
 		if (!cmd)
 			return (NULL);
 		cmd->n = (*n)++;
-		;
-		cmd->redir = parse_redir_tokens(tmp);
 		cmd->cmd_arg = parse_cmd_arg_tokens(tmp);
 		cmd->type = cmd->cmd_arg->type;
+		cmd->in_redir = parse_redir_tokens(tmp, "input");
+		cmd->out_redir = parse_redir_tokens(tmp, "output");
 		cmd_add_back(&cmds, cmd);
 		while (tmp && tmp->type != PIPE)
 			tmp = tmp->next;

--- a/src/print_utils.c
+++ b/src/print_utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/04 13:02:41 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/09 22:43:29 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/13 13:59:15 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,8 +66,15 @@ void	print_cmds(t_cmd *cmds)
 			ft_printf("\t\t%s: %s\n", enum_to_char(tmp->type), tmp->value);
 			tmp = tmp->next;
 		}
-		tmp = cmds->redir;
-		ft_printf("\tREDIR\n");
+		tmp = cmds->in_redir;
+		ft_printf("\tIN_REDIR\n");
+		while (tmp)
+		{
+			ft_printf("\t\t%s: %s\n", enum_to_char(tmp->type), tmp->value);
+			tmp = tmp->next;
+		}
+		tmp = cmds->out_redir;
+		ft_printf("\tOUT_REDIR\n");
 		while (tmp)
 		{
 			ft_printf("\t\t%s: %s\n", enum_to_char(tmp->type), tmp->value);

--- a/src/tokenizer_utils.c
+++ b/src/tokenizer_utils.c
@@ -6,23 +6,26 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/05 10:42:50 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/09 21:54:03 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/13 14:30:48 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-bool	is_redir(t_token *token)
+bool is_redir(t_token *token, char *redir_type)
 {
-	if (token->type == INRED)
-		return (true);
-	else if (token->type == OUTRED)
-		return (true);
-	else if (token->type == HERE_DOC)
-		return (true);
-	else if (token->type == APPEND)
-		return (true);
-	return (false);
+    if (!token || !redir_type)
+        return false;
+    if (ft_strcmp(redir_type, "input") == 0)
+	{
+        if (token->type == INRED || token->type == HERE_DOC)
+            return true;
+    } else if (ft_strcmp(redir_type, "output") == 0)
+	{
+        if (token->type == OUTRED || token->type == APPEND)
+            return true;
+    }
+    return false;
 }
 
 bool	is_builtin(t_token *token)

--- a/src/validation.c
+++ b/src/validation.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:35:57 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/13 23:26:55 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/13 23:48:28 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,12 +56,18 @@ int	validate_executable(t_macro *macro, t_cmd *cmd)
 	char	*full_path;
 	int		exit_code;
 
+	full_path == NULL;
 	if (ft_strchr("./", cmd->cmd_arg->value[0]) == NULL)
+	{
 		full_path = search_for_executable(macro, cmd);
-	if (!full_path)
-		return (-1);
-	free(cmd->cmd_arg->value);
-	cmd->cmd_arg->value = full_path;
+		if (!full_path)
+			return (-1);
+		else
+		{
+			free(cmd->cmd_arg->value);
+			cmd->cmd_arg->value = full_path;
+		}
+	}
 	exit_code = validate_access(cmd->cmd_arg->value);
 	return (exit_code);
 }

--- a/src/validation.c
+++ b/src/validation.c
@@ -6,218 +6,62 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:35:57 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/13 23:12:04 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/13 23:26:55 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	open_file(t_token *token)
-{
-	int	fd;
-
-	// if (macro->here_doc == 1)
-	//  macro->out_fd = open(macro->outfile, O_WRONLY | O_CREAT | O_APPEND,0644);
-	// else
-	if (token->type == INRED)
-		fd = open(token->value, O_RDONLY);
-	else if (token->type == OUTRED)
-		fd = open(token->value, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-	else if (token->type == APPEND)
-		fd = open(token->value, O_WRONLY | O_CREAT | O_APPEND, 0644);
-	if (errno == ENOENT)
-		return (-1);
-	if (errno == EACCES)
-		return (-1);
-	if (errno == IS_DIRECTORY)
-		return (-1);
-	return (fd);
-}
-
-int	open_last_redir_file(t_token *redir)
-{
-	t_token	*tmp;
-	int		fd;
-	t_type	type;
-
-	tmp = redir;
-	fd = -1;
-	while (tmp)
-	{
-		if (tmp->type == HERE_DOC)
-		{
-			tmp = tmp->next;
-			continue ;
-		}
-		fd = open_file(tmp);
-		if (fd == -1)
-			break ;
-		if (tmp->next != NULL)
-		{
-			close(fd);
-			fd = -1;
-		}
-		tmp = tmp->next;
-	}
-	return (fd);
-}
-
-void	dup_stdout(t_macro *macro, t_cmd *cmd)
-{
-	int	fd;
-
-	fd = open_last_redir_file(cmd->out_redir);
-	if (fd >= 1)
-	{
-		if (dup2(fd, STDOUT_FILENO) < 0)
-		{
-			perror("dup2 stdout");
-			close(fd);
-			return ;
-		}
-		close(fd);
-	}
-	else if (cmd->n < macro->num_cmds)
-	{
-		if (dup2(macro->pipe_fd[1], STDOUT_FILENO) < 0)
-		{
-			perror("dup2 pipe write");
-			return ;
-		}
-	}
-	close(macro->pipe_fd[1]);
-}
-
-void	dup_stdin(t_macro *macro, t_cmd *cmd, int read_end)
-{
-	int	fd;
-
-	// add here_doc fd here if the only one
-	fd = open_last_redir_file(cmd->in_redir);
-	if (fd >= 1)
-	{
-		if (dup2(fd, STDIN_FILENO) < 0)
-		{
-			perror("dup2 stdin");
-			close(fd);
-			return ;
-		}
-		close(fd);
-	}
-	else if (cmd->n > 1)
-	{
-		if (dup2(read_end, STDIN_FILENO) < 0)
-		{
-			perror("dup2 pipe read");
-			return ;
-		}
-	}
-	close(macro->pipe_fd[0]);
-}
-
-void	dup_file_descriptors(t_macro *macro, t_cmd *cmd, int read_end)
-{
-	dup_stdout(macro, cmd);
-	dup_stdin(macro, cmd, read_end);
-}
-
-bool	is_directory(const char *path)
-{
-	DIR	*dir;
-
-	dir = opendir(path);
-	if (dir != NULL)
-	{
-		closedir(dir);
-		return (true);
-	}
-	return (false);
-}
-
-int	validate_access(char *file)
+static int	validate_access(char *file)
 {
 	if (!access(file, F_OK))
 	{
 		if (!access(file, X_OK))
 		{
 			if (is_directory(file))
-				return(error_msg(file, 126));
-			return(0);
+				return (error_msg(file, 126));
+			return (0);
 		}
-		return(error_msg(file, 126));		
+		return (error_msg(file, 126));
 	}
-	return(error_msg(file, 127));
+	return (error_msg(file, 127));
 }
 
-static char	**parse_paths(char **env)
-{
-	int		i;
-	char	**paths;
-
-	i = 0;
-	if (!env)
-		return (NULL);
-	while (env[i])
-	{
-		if (ft_strnstr(env[i], "PATH=", 5))
-		{
-			paths = ft_split(env[i] + 5, ':');
-			return (paths);
-		}
-		i++;
-	}
-	return (NULL);
-}
-
-char	*get_executable_path(t_macro *macro, char **paths, char *executable)
-{
-	int		i;
-	char	*full_path;
-
-	i = 0;
-	while (paths[i])
-	{
-		full_path = ft_strjoin(paths[i], executable, "/");
-		if (full_path == NULL)
-			return (NULL);
-		if (!access(full_path, F_OK))
-			return (full_path);
-		free(full_path);
-		i++;
-	}
-	ft_putstr_fd("Executable not found\n", 2);
-	return (NULL);
-}
-
-
-
-int	validate_executable(t_macro *macro, t_cmd *cmd)
+static char	*search_for_executable(t_macro *macro, t_cmd *cmd)
 {
 	char	*executable;
 	char	**paths;
 	char	*full_path;
 
-	if (ft_strchr("./", cmd->cmd_arg->value[0]) == NULL)
+	executable = ft_strdup(cmd->cmd_arg->value);
+	if (!executable)
+		return (NULL);
+	paths = parse_paths(macro->env);
+	if (!paths)
 	{
-		executable = ft_strdup(cmd->cmd_arg->value);
-		if (!executable)
-			return (-1);
-		paths = parse_paths(macro->env);
-		if (!paths)
-		{
-			free(executable);
-			return (-1);
-		}
-		full_path = get_executable_path(macro, paths, executable);
-		if (full_path)
-		{
-			free(cmd->cmd_arg->value);
-			cmd->cmd_arg->value = full_path;
-		}
-		free(paths);
 		free(executable);
+		return (NULL);
 	}
-	return(validate_access(cmd->cmd_arg->value));
+	full_path = get_executable_path(macro, paths, executable);
+	free(paths);
+	free(executable);
+	if (!full_path)
+		return (NULL);
+	else
+		return (full_path);
 }
 
+int	validate_executable(t_macro *macro, t_cmd *cmd)
+{
+	char	*full_path;
+	int		exit_code;
 
+	if (ft_strchr("./", cmd->cmd_arg->value[0]) == NULL)
+		full_path = search_for_executable(macro, cmd);
+	if (!full_path)
+		return (-1);
+	free(cmd->cmd_arg->value);
+	cmd->cmd_arg->value = full_path;
+	exit_code = validate_access(cmd->cmd_arg->value);
+	return (exit_code);
+}

--- a/src/validation.c
+++ b/src/validation.c
@@ -6,36 +6,25 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:35:57 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/10 13:05:41 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/13 16:08:01 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	open_infile(char *infile)
-{
-	int	fd;
-
-	// if (macro->here_doc == 1)
-	// 	here_doc(macro);
-	fd = open(infile, O_RDONLY);
-	if (errno == ENOENT)
-		return (-1);
-	if (errno == EACCES)
-		return (-1);
-	if (errno == IS_DIRECTORY)
-		return (-1);
-	return (fd);
-}
-
-int	open_outfile(char *outfile)
+int	open_file(t_token *token)
 {
 	int	fd;
 
 	// if (macro->here_doc == 1)
 	//  macro->out_fd = open(macro->outfile, O_WRONLY | O_CREAT | O_APPEND,0644);
 	// else
-	fd = open(outfile, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if(token->type == INRED)
+		fd = open(token->value, O_RDONLY);
+	else if(token->type == OUTRED)
+		fd = open(token->value, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	else if(token->type == APPEND)
+		fd = open(token->value, O_WRONLY | O_CREAT | O_APPEND, 0644);
 	if (errno == ENOENT)
 		return (-1);
 	if (errno == EACCES)
@@ -45,51 +34,28 @@ int	open_outfile(char *outfile)
 	return (fd);
 }
 
-int	open_last_infile(t_token *redir)
+int	open_last_redir_file(t_token *redir)
 {
 	t_token	*tmp;
 	int		fd;
+	t_type type;
 
 	tmp = redir;
 	fd = -1;
 	while (tmp)
 	{
-		if (tmp->type == INRED)
+		if(tmp->type == HERE_DOC)
+        {
+            tmp = tmp->next;
+            continue;
+        }
+		fd = open_file(tmp);
+		if (fd == -1)
+			break ;
+		if (tmp->next != NULL)
 		{
-			fd = open_infile(tmp->value);
-			if (fd == -1)
-				break ;
-			if (!is_last_of_type(tmp, INRED))
-			{
-				if (fd != 0)
-					close(fd);
-				fd = 0;
-			}
-		}
-		tmp = tmp->next;
-	}
-	return (fd);
-}
-
-int	open_last_outfile(t_token *redir)
-{
-	t_token	*tmp;
-	int		fd;
-
-	tmp = redir;
-	fd = -1;
-	while (tmp)
-	{
-		if (tmp->type == OUTRED)
-		{
-			fd = open_outfile(tmp->value);
-			if (fd == -1)
-				break ;
-			if (!is_last_of_type(tmp, OUTRED))
-			{
-				close(fd);
-				fd = -1;
-			}
+			close(fd);
+			fd = -1;
 		}
 		tmp = tmp->next;
 	}
@@ -100,9 +66,7 @@ void	dup_stdout(t_macro *macro, t_cmd *cmd)
 {
 	int	fd;
 
-	fd = open_last_outfile(cmd->redir);
-	if (fd == -1)
-		return ;
+	fd = open_last_redir_file(cmd->out_redir);
 	if (fd >= 1)
 	{
 		if (dup2(fd, STDOUT_FILENO) < 0)
@@ -128,10 +92,9 @@ void	dup_stdin(t_macro *macro, t_cmd *cmd, int read_end)
 {
 	int	fd;
 
-	fd = open_last_infile(cmd->redir);
-	if (fd == -1)
-		return ;
-	if (fd >= 0)
+	//add here_doc fd here if the only one
+	fd = open_last_redir_file(cmd->in_redir);
+	if (fd >= 1)
 	{
 		if (dup2(fd, STDIN_FILENO) < 0)
 		{

--- a/src/validation.c
+++ b/src/validation.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:35:57 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/13 16:08:01 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/13 23:12:04 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,11 +19,11 @@ int	open_file(t_token *token)
 	// if (macro->here_doc == 1)
 	//  macro->out_fd = open(macro->outfile, O_WRONLY | O_CREAT | O_APPEND,0644);
 	// else
-	if(token->type == INRED)
+	if (token->type == INRED)
 		fd = open(token->value, O_RDONLY);
-	else if(token->type == OUTRED)
+	else if (token->type == OUTRED)
 		fd = open(token->value, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-	else if(token->type == APPEND)
+	else if (token->type == APPEND)
 		fd = open(token->value, O_WRONLY | O_CREAT | O_APPEND, 0644);
 	if (errno == ENOENT)
 		return (-1);
@@ -38,17 +38,17 @@ int	open_last_redir_file(t_token *redir)
 {
 	t_token	*tmp;
 	int		fd;
-	t_type type;
+	t_type	type;
 
 	tmp = redir;
 	fd = -1;
 	while (tmp)
 	{
-		if(tmp->type == HERE_DOC)
-        {
-            tmp = tmp->next;
-            continue;
-        }
+		if (tmp->type == HERE_DOC)
+		{
+			tmp = tmp->next;
+			continue ;
+		}
 		fd = open_file(tmp);
 		if (fd == -1)
 			break ;
@@ -92,7 +92,7 @@ void	dup_stdin(t_macro *macro, t_cmd *cmd, int read_end)
 {
 	int	fd;
 
-	//add here_doc fd here if the only one
+	// add here_doc fd here if the only one
 	fd = open_last_redir_file(cmd->in_redir);
 	if (fd >= 1)
 	{
@@ -120,3 +120,104 @@ void	dup_file_descriptors(t_macro *macro, t_cmd *cmd, int read_end)
 	dup_stdout(macro, cmd);
 	dup_stdin(macro, cmd, read_end);
 }
+
+bool	is_directory(const char *path)
+{
+	DIR	*dir;
+
+	dir = opendir(path);
+	if (dir != NULL)
+	{
+		closedir(dir);
+		return (true);
+	}
+	return (false);
+}
+
+int	validate_access(char *file)
+{
+	if (!access(file, F_OK))
+	{
+		if (!access(file, X_OK))
+		{
+			if (is_directory(file))
+				return(error_msg(file, 126));
+			return(0);
+		}
+		return(error_msg(file, 126));		
+	}
+	return(error_msg(file, 127));
+}
+
+static char	**parse_paths(char **env)
+{
+	int		i;
+	char	**paths;
+
+	i = 0;
+	if (!env)
+		return (NULL);
+	while (env[i])
+	{
+		if (ft_strnstr(env[i], "PATH=", 5))
+		{
+			paths = ft_split(env[i] + 5, ':');
+			return (paths);
+		}
+		i++;
+	}
+	return (NULL);
+}
+
+char	*get_executable_path(t_macro *macro, char **paths, char *executable)
+{
+	int		i;
+	char	*full_path;
+
+	i = 0;
+	while (paths[i])
+	{
+		full_path = ft_strjoin(paths[i], executable, "/");
+		if (full_path == NULL)
+			return (NULL);
+		if (!access(full_path, F_OK))
+			return (full_path);
+		free(full_path);
+		i++;
+	}
+	ft_putstr_fd("Executable not found\n", 2);
+	return (NULL);
+}
+
+
+
+int	validate_executable(t_macro *macro, t_cmd *cmd)
+{
+	char	*executable;
+	char	**paths;
+	char	*full_path;
+
+	if (ft_strchr("./", cmd->cmd_arg->value[0]) == NULL)
+	{
+		executable = ft_strdup(cmd->cmd_arg->value);
+		if (!executable)
+			return (-1);
+		paths = parse_paths(macro->env);
+		if (!paths)
+		{
+			free(executable);
+			return (-1);
+		}
+		full_path = get_executable_path(macro, paths, executable);
+		if (full_path)
+		{
+			free(cmd->cmd_arg->value);
+			cmd->cmd_arg->value = full_path;
+		}
+		free(paths);
+		free(executable);
+	}
+	return(validate_access(cmd->cmd_arg->value));
+}
+
+

--- a/src/validation_utils.c
+++ b/src/validation_utils.c
@@ -1,0 +1,66 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   validation_utils.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/13 23:25:19 by pmarkaid          #+#    #+#             */
+/*   Updated: 2024/08/13 23:26:30 by pmarkaid         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+bool	is_directory(const char *path)
+{
+	DIR	*dir;
+
+	dir = opendir(path);
+	if (dir != NULL)
+	{
+		closedir(dir);
+		return (true);
+	}
+	return (false);
+}
+
+char	**parse_paths(char **env)
+{
+	int		i;
+	char	**paths;
+
+	i = 0;
+	if (!env)
+		return (NULL);
+	while (env[i])
+	{
+		if (ft_strnstr(env[i], "PATH=", 5))
+		{
+			paths = ft_split(env[i] + 5, ':');
+			return (paths);
+		}
+		i++;
+	}
+	return (NULL);
+}
+
+char	*get_executable_path(t_macro *macro, char **paths, char *executable)
+{
+	int		i;
+	char	*full_path;
+
+	i = 0;
+	while (paths[i])
+	{
+		full_path = ft_strjoin(paths[i], executable, "/");
+		if (full_path == NULL)
+			return (NULL);
+		if (!access(full_path, F_OK))
+			return (full_path);
+		free(full_path);
+		i++;
+	}
+	ft_putstr_fd("Executable not found\n", 2);
+	return (NULL);
+}


### PR DESCRIPTION
- minishell now evaluate if the executable has a relative or absolute path. If given, it will evaluate for permissions the executable. If not given, if will use PATH envir to search for the binary.
- In conclusion, we can use directly cat instead of /usr/bin/cat
- NB! handles executables, but does not evaluate for our builtins, so error may occur