### PR TITLE
feat: plug Builtins into execution module

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/15 09:29:01 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/15 12:28:09 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -93,8 +93,6 @@ typedef struct s_macro
 	t_cmd			*cmds;
 	int				num_cmds;
 	int				pipe_fd[2];
-	int				in_fd;
-	int				out_fd;
 	pid_t			*pid;
 }					t_macro;
 
@@ -135,6 +133,8 @@ int					execution(t_macro *macro);
 
 /* execution utils */
 char				**build_cmd_args_array(t_token *cmd_args);
+int	get_exit_code(int status);
+int	wait_processes(pid_t *pid, int cmds);
 
 /* validation */
 int					validate_executable(t_macro *macro, t_cmd *cmd);
@@ -175,7 +175,7 @@ int					ft_strchr_i(const char *s, int c);
 char				**ft_replace_matrix_row(char ***big, char **small, int n);
 void				ft_unset(t_macro *macro);
 int					var_in_env(char *argv, char **env, int ij[2]);
-int					exec_builtin(char *cmd, char **args, t_macro *macro);
+int					select_and_run_builtin(char *cmd, char **args, t_macro *macro);
 bool				check_builtin(char *real_cmd);
 char				*grab_env(char *var, char **env, int n);
 char				**fix_env(char *var, char *value, char **env, int n);

--- a/src/bu_func.c
+++ b/src/bu_func.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   bu_func.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/09 15:55:31 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/08/15 09:43:27 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/15 13:05:14 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,18 +41,17 @@ void	test_builtins(t_macro *macro)
 
 char *remove_path(char *cmd)
 {
-	int		pos;
-	char	*real_cmd;
+    char *pos;
+    char *real_cmd;
 
-	pos = ft_strchr_last(cmd, '/');
-	//printf("pos: %d\n", pos);
-	if (pos == 0)
-		return (cmd);
-	real_cmd = ft_substr(cmd, pos + 1, ft_strlen(cmd));
-	return (real_cmd);
+    pos = ft_strrchr(cmd, '/');
+    if (pos == NULL)
+        return (cmd);
+    real_cmd = ft_substr(pos + 1, 0, ft_strlen(pos + 1));
+    return (real_cmd);
 }
 
-
+// remove this if not needed
 bool	check_builtin(char *real_cmd)
 {
 	if (ft_strncmp(real_cmd, "echo", 4) == 0)
@@ -246,7 +245,7 @@ int ft_cd2(char **args, t_macro *macro)
 	return (0);
 }
 
-int	exec_builtin(char *cmd, char **args, t_macro *macro)
+int	select_and_run_builtin(char *cmd, char **args, t_macro *macro)
 {
 	//printf("dentro de exec_builtin cmd ##%s\n", cmd);
 	if (ft_strncmp(cmd, "echo", 4) == 0)

--- a/src/env.c
+++ b/src/env.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/07 09:11:22 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/08/15 08:54:27 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/15 12:21:46 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,26 +30,6 @@ int	ft_strchr_i(const char *s, int c)
 	if (c_unsigned == '\0')
 		return (i);
 	return (-1);
-}
-
-int	ft_strchr_last(const char *s, int c)
-{
-	unsigned char	c_unsigned;
-	int				i;
-	int				j;
-
-	i = 0;
-	j = 0;
-	if (!s)
-		return (-1);
-	c_unsigned = (unsigned char)c;
-	while (s[i] != '\0')
-	{
-		if (s[i] == c_unsigned)
-			j = i;
-		i++;
-	}
-	return (j);
 }
 
 int	var_in_env(char *argv, char **env, int ij[2])

--- a/src/execution_utils.c
+++ b/src/execution_utils.c
@@ -6,11 +6,41 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/09 20:03:14 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/09 20:12:05 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/15 12:25:29 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+int	get_exit_code(int status)
+{
+	int	exit_code;
+
+	exit_code = 0;
+	if (WIFSIGNALED(status))
+		exit_code = 128 + WTERMSIG(status);
+	else if (WIFEXITED(status))
+		exit_code = WEXITSTATUS(status);
+	return (exit_code);
+}
+
+int	wait_processes(pid_t *pid, int cmds)
+{
+	int	i;
+	int	status;
+	int	exit_code;
+
+	i = 0;
+	exit_code = 0;
+	while (i < cmds)
+	{
+		waitpid(pid[i], &status, 0);
+		if (i == cmds - 1)
+			exit_code = get_exit_code(status);
+		i++;
+	}
+	return (exit_code);
+}
 
 char	**build_cmd_args_array(t_token *cmd_args)
 {

--- a/src/validation.c
+++ b/src/validation.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:35:57 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/14 12:33:15 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/15 13:32:58 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,5 +68,7 @@ int	validate_executable(t_macro *macro, t_cmd *cmd)
 		}
 	}
 	exit_code = validate_access(cmd->cmd_arg->value);
-	return (exit_code);
+	if(exit_code != 0)
+		ft_putstr_fd("executable not found\n",2);
+	return(exit_code);
 }


### PR DESCRIPTION
Builtins are now working fully in minishell execution.

If the builtin is the only command in the instruction, is executed on the parent, and any changes will be reflected on the parent process (change directory, change environmental variables etc.).

With more than one command, the builtins are treated as commands and executed inside a fork. In this case, changes to the environment have no effect on the parent process.

NB! Builtins still don't have a PID and wait handling