### PR TITLE
New Export builtin to match bash behavior

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/15 09:04:34 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/15 22:13:42 by dbejar-s         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -79,8 +79,8 @@ int	main(int argc, char **argv, char **envp)
 		{
 			perror("Error getting current directory");
 		}
-		path = ft_strjoin("minishell> ", path, NULL);
-		path = ft_strjoin(path, " $ ", NULL);
+		path = ft_strjoin(path, " @ minishell>$ ", NULL);
+		//path = ft_strjoin(path, " $ ", NULL);
 		line = readline(path);
 		if (line == NULL || *line == EOF)
 		{


### PR DESCRIPTION
Three comments after merging your two last PR
1. When there is only one command like "echo test > out", the new function added in execution only executes the builtin, but it doesn't get to dup_file_descriptors... so, it doesn't manage the OUTRED. A similar function like execute_child_process is required.
2. If you export the variable TEST=123456 and then, run echo $TEST, it only prints 1234,  it's like the arg is truncated with the same amount of chars than the variable name
3. If you run "echo $TEST$TEST$TEST", it prints the internal value just once (taking into account problem number 2). The arg that arrives to the echo builtin function contains only the assigned value of one $TEST 