### PR TITLE
feat: handle environmental expansion based on quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/08/01 15:11:43 by pmarkaid          #+#    #+#              #
-#    Updated: 2024/08/16 00:04:27 by pmarkaid         ###   ########.fr        #
+#    Updated: 2024/08/16 00:23:14 by pmarkaid         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -51,7 +51,7 @@ TEST_OBJS = $(TEST_SRCS:.c=.o)
 TEST_NAME = tests_runner
 
 CC = cc 
-CFLAGS = -Wall -Werror -g
+CFLAGS = -Wall -Werror -Wextra -g
 DEBUG_FLAGS = -g
 
 # External Libraries

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/08/01 15:11:43 by pmarkaid          #+#    #+#              #
-#    Updated: 2024/08/14 12:34:42 by pmarkaid         ###   ########.fr        #
+#    Updated: 2024/08/16 00:04:27 by pmarkaid         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -32,7 +32,9 @@ SRCS_FILES = \
 	execution.c \
 	execution_utils.c \
 	error.c \
-	dup.c
+	dup.c \
+	clean.c \
+	clean_utils.c
 
 SRC_DIR = src/
 SRCS = $(addprefix $(SRC_DIR), $(SRCS_FILES))
@@ -49,7 +51,7 @@ TEST_OBJS = $(TEST_SRCS:.c=.o)
 TEST_NAME = tests_runner
 
 CC = cc 
-CFLAGS = -Wall -Werror -Wextra -g
+CFLAGS = -Wall -Werror -g
 DEBUG_FLAGS = -g
 
 # External Libraries

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/15 12:28:09 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/16 00:09:18 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -104,7 +104,7 @@ void				tokenizer(t_macro *macro);
 
 /* tokenizer_utils */
 bool				is_inside_single_quotes(const char *str, int index);
-char				*expand_envirs(char *clean, char *instruction, t_macro *macro);
+char				*expand_envir(char *clean, char *instruction, t_macro *macro);
 bool				is_builtin(t_token *token);
 bool				is_redir(t_token *token, char *redir_type);
 
@@ -147,9 +147,13 @@ char				*get_executable_path(char **paths, char *executable);
 /* dup */
 void				dup_file_descriptors(t_macro *macro, t_cmd *cmd, int read_end);
 
-/* tests */
-char				*get_envir_value(const char *str, int *len, t_macro *macro);
-size_t				expanded_envir_len(char *instruction, t_macro *macro);
+/* clean */
+void				clean(t_macro *macro);
+
+/* clean utils*/
+char				*get_envir_name(char *str);
+char				*get_envir_value(char *str, t_macro *macro);
+bool				envir_must_be_expanded(char *instruction, int index);
 
 /* free */
 void				free_array(char ***array);

--- a/src/clean.c
+++ b/src/clean.c
@@ -1,0 +1,123 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   clean.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/15 15:39:10 by pmarkaid          #+#    #+#             */
+/*   Updated: 2024/08/16 00:06:34 by pmarkaid         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+/*
+ * Transverse the original instruction
+ * If envir surrounded by S quotes, continue
+ * If envir surrounded by double quotes, expand, maintaining the quotes
+ * If envirs outside quotes, expand without quotes
+ * Tokenize the new instruction
+ * Continue parsing, execution etc.
+ */
+
+static char	*clean_instruction(char *instruction)
+{
+	char	*clean;
+	char	*ptr;
+	int		i;
+
+	clean = malloc(sizeof(char) * ft_strlen(instruction) + 1);
+	ptr = instruction;
+	i = 0;
+	while (*ptr)
+	{
+		// Riesgo de Segfault si da la casualidad de que ptr[0] es espacio e intenta leer ptr[-1]
+		if (*ptr == ' ' && (*(ptr - 1) == '<' || *(ptr - 1) == '>'))
+			ptr++;
+		clean[i] = *ptr;
+		i++;
+		ptr++;
+	}
+	clean[i] = '\0';
+	free(instruction);
+	return (clean);
+}
+
+char	*build_expanded_instruction(char *clean, char *instruction, t_macro *macro)
+{
+	int		i;
+	char	*envir_value;
+	char	*envir_name;
+
+	i = 0;
+	while (*instruction)
+	{
+		if (*instruction != '$')
+			clean[i++] = *instruction++;
+		else
+		{
+			instruction++;
+			envir_name = get_envir_name(instruction);
+			envir_value = get_envir_value(instruction, macro);
+			if (envir_name && envir_value)
+			{
+				ft_strlcpy(&clean[i], envir_value, ft_strlen(envir_value) + 1);
+				i += ft_strlen(envir_value);
+				free(envir_value);
+				instruction += ft_strlen(envir_name);
+			}
+		}
+	}
+	clean[i] = '\0';
+	return (clean);
+}
+
+size_t	expanded_instruction_len(char *instruction, t_macro *macro)
+{
+	size_t	len;
+	int		i;
+	char	*envir_value;
+
+	len = 0;
+	i = 0;
+	while (instruction[i])
+	{
+		if (instruction[i] == '$' && envir_must_be_expanded(instruction, i))
+		{
+			i++;
+			envir_value = get_envir_value(&instruction[i], macro);
+			if (envir_value)
+				len += ft_strlen(envir_value);
+		}
+		else
+		{
+			len++;
+			i++;
+		}
+	}
+	return (len);
+}
+
+static char	*get_expanded_instruction(char *instruction, t_macro *macro)
+{
+	char	*clean;
+	int		env_len;
+	size_t	total_len;
+
+	env_len = expanded_instruction_len(instruction, macro);
+	total_len = env_len + ft_strlen(instruction);
+	clean = calloc(1, sizeof(char) * total_len + 1);
+	if (!clean)
+		return (NULL);
+	clean = build_expanded_instruction(clean, instruction, macro);
+	clean[total_len] = '\0';
+	free(instruction);
+	return (clean);
+}
+
+void clean(t_macro *macro)
+{
+	macro->instruction = get_expanded_instruction(macro->instruction, macro);
+	macro->instruction = clean_instruction(macro->instruction);
+}

--- a/src/clean_utils.c
+++ b/src/clean_utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/15 22:56:08 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/16 00:09:09 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/16 01:07:26 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -79,12 +79,11 @@ bool	is_not_in_quote(char *str, int index)
 	return (true);
 }
 
-bool	envir_must_be_expanded(char *instruction, int index)
+bool envir_must_be_expanded(char *str, int index)
 {
-	bool	not_in_quotes;
-	bool	not_in_quote;
-
-	not_in_quotes = is_inside_double_quotes(instruction, index);
-	not_in_quote = is_not_in_quote(instruction, index);
-	return (not_in_quotes || not_in_quote);
+    if (is_not_in_quote(str, index))
+        return true;
+    if (is_inside_double_quotes(str, index))
+        return true;
+    return false;
 }

--- a/src/clean_utils.c
+++ b/src/clean_utils.c
@@ -1,0 +1,90 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   clean_utils.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/15 22:56:08 by pmarkaid          #+#    #+#             */
+/*   Updated: 2024/08/16 00:09:09 by pmarkaid         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+char	*get_envir_name(char *str)
+{
+	int		i;
+	char	*envir_name;
+
+	i = 0;
+	while (str[i] && (ft_isalnum(str[i]) || str[i] == '_'))
+		i++;
+	envir_name = ft_substr(str, 0, i);
+	if (!envir_name)
+		return (NULL);
+	return (envir_name);
+}
+
+char	*get_envir_value(char *str, t_macro *macro)
+{
+	char	*envir_name;
+	char	*envir_value;
+
+	envir_name = get_envir_name(str);
+	if (!envir_name)
+		return (NULL);
+	envir_value = ft_getenv(envir_name, macro->env);
+	free(envir_name);
+	if (!envir_value)
+		return (NULL);
+	return (envir_value);
+}
+
+bool	is_inside_double_quotes(char *str, int index)
+{
+	bool	inside_double_quotes;
+	int		i;
+
+	inside_double_quotes = false;
+	i = 0;
+	while (i <= index && str[i] != '\0')
+	{
+		if (str[i] == '\"')
+			inside_double_quotes = !inside_double_quotes;
+		i++;
+	}
+	return (inside_double_quotes);
+}
+
+bool	is_not_in_quote(char *str, int index)
+{
+	bool	inside_single_quotes;
+	bool	inside_double_quotes;
+	int		i;
+
+	inside_single_quotes = false;
+	inside_double_quotes = false;
+	i = 0;
+	while (i <= index && str[i] != '\0')
+	{
+		if (str[i] == '\'')
+			inside_single_quotes = !inside_single_quotes;
+		if (str[i] == '\"')
+			inside_double_quotes = !inside_double_quotes;
+		i++;
+	}
+	if (inside_single_quotes || inside_double_quotes)
+		return (false);
+	return (true);
+}
+
+bool	envir_must_be_expanded(char *instruction, int index)
+{
+	bool	not_in_quotes;
+	bool	not_in_quote;
+
+	not_in_quotes = is_inside_double_quotes(instruction, index);
+	not_in_quote = is_not_in_quote(instruction, index);
+	return (not_in_quotes || not_in_quote);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/15 09:04:34 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/16 00:07:42 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -96,6 +96,7 @@ int	main(int argc, char **argv, char **envp)
 			continue ;
 		}
 		macro->instruction = line;
+		clean(macro);
 		tokenizer(macro);
 		//test_builtins(macro);
 		macro->cmds = parsing(macro);

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   tokenizer.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/03 21:24:44 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/15 09:05:17 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/16 00:04:55 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,49 +83,12 @@ t_token	*identify_tokens(char **lexemes)
 	return (tokens);
 }
 
-static char	*clean_instruction(char *instruction)
-{
-	char	*clean;
-	char	*ptr;
-	int		i;
 
-	clean = malloc(sizeof(char) * ft_strlen(instruction) + 1);
-	ptr = instruction;
-	i = 0;
-	while (*ptr)
-	{
-		if (*ptr == ' ' && (*(ptr - 1) == '<' || *(ptr - 1) == '>'))//Riesgo de Segfault si da la casualidad de que ptr[0] es espacio e intenta leer ptr[-1]
-			ptr++;
-		clean[i] = *ptr;
-		i++;
-		ptr++;
-	}
-	clean[i] = '\0';
-	return (clean);
-}
-
-static char	*get_expanded_instruction(char *instruction, t_macro *macro)
-{
-	char	*clean;
-	size_t	total_len;
-
-	if (!instruction)
-		return (NULL);
-	total_len = expanded_envir_len(instruction, macro) + ft_strlen(instruction);
-	clean = calloc(1, sizeof(char) * total_len + 1);
-	if (!clean)
-		return (NULL);
-	clean = expand_envirs(clean, instruction, macro);
-	clean[total_len] = '\0';
-	return (clean);
-}
 
 void	tokenizer(t_macro *macro)
 {
 	char	**lexemes;
 
-	macro->instruction = get_expanded_instruction(macro->instruction, macro);
-	macro->instruction = clean_instruction(macro->instruction);
 	lexemes = ft_split(macro->instruction, ' ');
 	macro->tokens = identify_tokens(lexemes);
 	//print_tokens(macro->tokens);

--- a/src/tokenizer_utils.c
+++ b/src/tokenizer_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   tokenizer_utils.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/05 10:42:50 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/15 08:51:38 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/15 23:53:19 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,102 +47,4 @@ bool	is_builtin(t_token *token)
 	return (false);
 }
 
-bool	is_inside_single_quotes(const char *str, int index)
-{
-	bool	inside_single_quotes;
-	int		i;
 
-	inside_single_quotes = false;
-	i = 0;
-	while (i <= index && str[i] != '\0')
-	{
-		if (str[i] == '\'' && (i == 0 || str[i - 1] != '\\'))
-			inside_single_quotes = !inside_single_quotes;
-		i++;
-	}
-	return (inside_single_quotes);
-}
-
-char	*get_envir_value(const char *str, int *len, t_macro *macro)
-{
-	char	*envir_name;
-	char	*envir_value;
-
-	*len = 0;
-	while (ft_isalnum(str[*len]) || str[*len] == '_')
-		(*len)++;
-	envir_name = (char *)malloc(*len + 1);
-	if (envir_name)
-	{
-		ft_strncpy(envir_name, str, *len);
-		envir_name[*len] = '\0';
-	}
-	else
-		return (NULL);
-	//envir_value = getenv(envir_name);//GETENV -->> buscar en la matriz de env!!!
-	envir_value = ft_getenv(envir_name, macro->env);
-	free(envir_name);
-	return (envir_value);
-}
-
-size_t	expanded_envir_len(char *instruction, t_macro *macro)
-{
-	size_t	len;
-	int		i;
-	char	*ptr;
-	char	*envir_value;
-	int		envir_name_len;
-
-	if (!instruction)
-		return (0);
-	len = 0;
-	i = 0;
-	ptr = instruction;
-	while (ptr[i])
-	{
-		if (ptr[i] == '$' && !is_inside_single_quotes(ptr, i))
-		{
-			if (ptr[i + 1] == '\0')
-				break ;
-			envir_value = get_envir_value(&ptr[i + 1], &envir_name_len, macro);
-			if (envir_value)
-				len += ft_strlen(envir_value);
-			i += envir_name_len + 1;
-		}
-		else
-		{
-			len++;
-			i++;
-		}
-	}
-	return (len);
-}
-
-char	*expand_envirs(char *clean, char *instruction, t_macro *macro)
-{
-	char	*ptr;
-	int		i;
-	int		len;
-	char	*envir_value;
-
-	ptr = instruction;
-	i = 0;
-	while (*ptr)
-	{
-		if (*ptr != '$')
-			clean[i++] = *ptr++;
-		else
-		{
-			ptr++;
-			envir_value = get_envir_value(ptr, &len, macro);
-			if (envir_value)
-			{
-				ft_strlcpy(&clean[i], envir_value, len + 1);
-				i += len;
-				free(envir_value);
-			}
-			ptr += len;
-		}
-	}
-	return (clean);
-}


### PR DESCRIPTION
This update adds a clean module that, before tokenization, expands the environmental variables based on quote rules. If inside a double quote or without any quotation, it expands variables. If single-quoted, it does not expand.