### PR TITLE
feat: remove edge and inner quotes from the tokens

### DIFF
--- a/lib/libft/Makefile
+++ b/lib/libft/Makefile
@@ -6,7 +6,7 @@
 #    By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/10/24 12:10:27 by pmarkaid          #+#    #+#              #
-#    Updated: 2024/08/18 16:09:12 by pmarkaid         ###   ########.fr        #
+#    Updated: 2024/08/19 13:47:27 by pmarkaid         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -81,7 +81,9 @@ SRC = \
 	ft_del.c \
 	ft_lst_to_array.c \
 	ft_isdelim.c \
-	ft_strndup.c
+	ft_strndup.c \
+	ft_clean_edge_quotes.c \
+	ft_remove_char.c
 
 INCLUDES = .
 

--- a/lib/libft/ft_clean_edge_quotes.c
+++ b/lib/libft/ft_clean_edge_quotes.c
@@ -1,0 +1,38 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_clean_edge_quotes.c                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/19 12:33:28 by pmarkaid          #+#    #+#             */
+/*   Updated: 2024/08/19 13:48:20 by pmarkaid         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+
+char *ft_remove_edge_quotes(char *str)
+{
+    int start = 0;
+    int end;
+    int len;
+    char *result;
+
+    if (str == NULL || *str == '\0')
+        return NULL;
+    len = ft_strlen(str);
+    if (len == 0)
+        return ft_strdup("");
+    end = len - 1;
+    while (str[start] == '\'' || str[start] == '\"')
+        start++;
+    while (end > start && (str[end] == '\'' || str[end] == '\"'))
+        end--;
+    result = malloc(end - start + 2);
+    if (result == NULL)
+        return(NULL);
+    ft_strncpy(result, str + start, end - start + 1);
+    result[end - start + 1] = '\0';
+    return result;
+}

--- a/lib/libft/ft_remove_char.c
+++ b/lib/libft/ft_remove_char.c
@@ -1,0 +1,41 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_remove_char.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/19 13:45:47 by pmarkaid          #+#    #+#             */
+/*   Updated: 2024/08/19 13:47:06 by pmarkaid         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+
+char	*ft_remove_char(char *str, char c)
+{
+	int		i;
+	int		j;
+	int		len;
+	char	*clean;
+
+	i = 0;
+	j = 0;
+	if (str == NULL)
+		return (NULL);
+	len = ft_strlen(str);
+	clean = malloc(sizeof(char) * len + 1);
+	if (!clean)
+		return (NULL);
+	while (str[i])
+	{
+		if (str[i] != c)
+		{
+			clean[j] = str[i];
+			j++;
+		}
+		i++;
+	}
+	clean[j] = '\0';
+	return (clean);
+}

--- a/lib/libft/libft.h
+++ b/lib/libft/libft.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/24 12:08:37 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/18 16:11:10 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/19 13:48:30 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -106,5 +106,7 @@ void				ft_del(void *content);
 char 				**ft_lst_to_array(t_list **lst);
 int					ft_isdelim(char c);
 char 				*ft_strndup(char *str, int n);
+char				*ft_remove_edge_quotes(char *str);
+char				*ft_remove_char(char *str, char c);
 
 #endif

--- a/src/clean.c
+++ b/src/clean.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/15 15:39:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/18 16:20:34 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/19 13:51:38 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -133,19 +133,35 @@ static char	*get_expanded_instruction(char *instruction, t_macro *macro)
 	return (clean);
 }
 
-static int	create_and_add_node(char *token_start, size_t length,
-		t_list **tokens)
+static char	*create_and_clean_token(char *start, size_t length)
 {
 	char	*token;
+	char	*clean_token;
+
+	token = ft_strndup(start, length);
+	if (!token)
+		return (NULL);
+	clean_token = ft_remove_edge_quotes(token);
+	free(token);
+	if (!clean_token)
+		return (NULL);
+	token = ft_remove_char(clean_token, '\"');
+	free(clean_token);
+	return (token);
+}
+
+static int	create_and_add_node(char *start, size_t length, t_list **tokens)
+{
+	char	*clean_token;
 	t_list	*new_node;
 
-	token = ft_strndup(token_start, length);
-	if (!token)
+	clean_token = create_and_clean_token(start, length);
+	if (!clean_token)
 		return (-1);
-	new_node = ft_lstnew(token);
+	new_node = ft_lstnew(clean_token);
 	if (!new_node)
 	{
-		free(token);
+		free(clean_token);
 		return (-1);
 	}
 	ft_lstadd_back(tokens, new_node);


### PR DESCRIPTION
After the initial tokenization, quotes are cleaned with the following rules:

- If you are an edge quote, remove. Both single and double
- After that, remove any inner double quote inside the string
- Inner single quotes shall be mantained