### PR TITLE
feat: presyntax evaluate quotes before rising an error

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/18 16:02:05 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/20 14:00:48 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -155,7 +155,7 @@ t_list				*split_args_by_quotes(char* input);
 char				*get_envir_name(char *str);
 char				*get_envir_value(char *str, t_macro *macro);
 bool				envir_must_be_expanded(char *instruction, int index);
-char*				find_next_token_start(char* current_position);
+bool				is_in_quote(char *str, int index);
 
 /* free */
 void				free_array(char ***array);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/20 14:00:48 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/20 14:53:38 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,25 +14,25 @@
 # define MINISHELL_H
 
 # include "../lib/libft/libft.h" /* libft library */
-# include <curses.h>             // tgetent, tgetflag, tgetnum, tgetstr, tgoto,tputs
+# include <curses.h>             // tgetent, tgetflag, tgetnum, tgetstr,
 # include <dirent.h>             // opendir, readdir, closedir
 # include <errno.h>              /* for errno */
 # include <fcntl.h>              // open
 # include <limits.h>             /* for LONG_MAX, LONG_MIN */
 # include <readline/history.h>   // add_history
-# include <readline/readline.h>  // readline, rl_clear_history, rl_on_new_line,rl_replace_line, rl_redisplay
-# include <signal.h>             // signal, sigaction, sigemptyset, sigaddset,kill
+# include <readline/readline.h>  // readline, rl_clear_history,rl_on_new_line
+# include <signal.h>             // signal, sigaction, sigemptyset,sigaddset
 # include <stdbool.h>            /* for true and false*/
 # include <stdio.h>              // printf, perror
 # include <stdlib.h>             // malloc, free, exit, getenv
 # include <string.h>             // strerror
 # include <sys/ioctl.h>          // ioctl
 # include <sys/stat.h>           // stat, lstat, fstat
-# include <sys/types.h>          // fork, wait, waitpid, wait3, wait4, stat,lstat, fstat
+# include <sys/types.h>          // fork, wait, waitpid, wait3, wait4,stat
 # include <sys/wait.h>           // wait, waitpid, wait3, wait4
-# include <term.h>               // tgetent, tgetflag, tgetnum, tgetstr,tgoto,tputs
+# include <term.h>               // tgetent, tgetflag, tgetnum,tgetstr,tgoto
 # include <termios.h>            // tcsetattr, tcgetattr
-# include <unistd.h>             // read, write, access, open, close,fork,getcwd, chdir, unlink, execve, dup, dup2, pipe, isatty, ttyname,ttyslot
+# include <unistd.h>             // read, write, access, open,close,fork
 
 # define NO_FILE 1
 # define PERMISSION_DENIED 126
@@ -104,7 +104,8 @@ void				tokenizer(t_macro *macro);
 
 /* tokenizer_utils */
 bool				is_inside_single_quotes(const char *str, int index);
-char				*expand_envir(char *clean, char *instruction, t_macro *macro);
+char				*expand_envir(char *clean, char *instruction,
+						t_macro *macro);
 bool				is_builtin(t_token *token);
 bool				is_redir(t_token *token, char *redir_type);
 
@@ -133,8 +134,8 @@ int					execution(t_macro *macro);
 
 /* execution utils */
 char				**build_cmd_args_array(t_token *cmd_args);
-int	get_exit_code(int status);
-int	wait_processes(pid_t *pid, int cmds);
+int					get_exit_code(int status);
+int					wait_processes(pid_t *pid, int cmds);
 
 /* validation */
 int					validate_executable(t_macro *macro, t_cmd *cmd);
@@ -149,7 +150,7 @@ void				dup_file_descriptors(t_macro *macro, t_cmd *cmd, int read_end);
 
 /* clean */
 void				clean(t_macro *macro);
-t_list				*split_args_by_quotes(char* input);
+t_list				*split_args_by_quotes(char *input);
 
 /* clean utils*/
 char				*get_envir_name(char *str);
@@ -185,12 +186,10 @@ int					select_and_run_builtin(char *cmd, char **args, t_macro *macro);
 bool				check_builtin(char *real_cmd);
 char				*grab_env(char *var, char **env, int n);
 char				**fix_env(char *var, char *value, char **env, int n);
-int					ft_strchr_last(const char *s, int c);
 char				*remove_path(char *cmd);
 t_macro				*init_macro(char **envp, char **argv);
 t_macro				*start_env(t_macro *macro, char **argv);
 char				*ft_getenv(char *var, char **env);
-
 
 /* error */
 int					error_msg(char *msg, int exit_code);

--- a/lib/libft/ft_remove_extra_spaces.c
+++ b/lib/libft/ft_remove_extra_spaces.c
@@ -6,13 +6,13 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 15:48:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/02 15:49:00 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/20 14:05:19 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-void	remove_extra_spaces(char *str)
+void	ft_remove_extra_spaces(char *str)
 {
 	int	i;
 	int	j;

--- a/lib/libft/ft_whitespaces_into_spaces.c
+++ b/lib/libft/ft_whitespaces_into_spaces.c
@@ -6,13 +6,13 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 15:49:31 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/02 15:49:38 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/20 14:05:42 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-void	white_spaces_into_spaces(char *str)
+void	ft_white_spaces_into_spaces(char *str)
 {
 	int	i;
 

--- a/lib/libft/libft.h
+++ b/lib/libft/libft.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   libft.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/24 12:08:37 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/19 15:52:48 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/20 14:05:32 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -96,8 +96,8 @@ char				*ft_strjoin(char const *s1, char const *s2, char *delim);
 int					ft_str_empty(char *str);
 char				*ft_strncpy(char *dest, const char *src, size_t n);
 
-void				remove_extra_spaces(char *str);
-void				white_spaces_into_spaces(char *str);
+void				ft_remove_extra_spaces(char *str);
+void				ft_white_spaces_into_spaces(char *str);
 int					ft_abs(int n);
 int					ft_isquote(char c);
 t_list				*ft_split_args(char *str, char *delim);

--- a/src/presyntax.c
+++ b/src/presyntax.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 15:12:06 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/20 14:47:30 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/20 15:02:08 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,8 +52,7 @@ static char	valid_file_name(char *instruction)
 				if (instruction[i + 1] == '\0')
 					return ('\n');
 				next_char = instruction[i + 1];
-				if (!ft_isalnum(next_char) && next_char != '|'
-					&& next_char != '$')
+				if (!ft_isalnum(next_char) && !strchr("$~+-./\'\"", next_char))
 					return (next_char);
 			}
 		}

--- a/src/presyntax.c
+++ b/src/presyntax.c
@@ -14,50 +14,51 @@
 
 static int	invalid_char_check(char *instruction)
 {
-    int 	i;
+	int	i;
 
-    i = 0;
-    while (instruction[i])
-    {
-        if (!is_in_quote(instruction, i))
-        {
-            if (instruction[i] == ';')
-                return(instruction[i]);
-            if (instruction[i] == '&')
-                return(instruction[i]);
-            if (instruction[i] == '|' && instruction[i + 1] == '|')
-                return(instruction[i]);
-        }
-        i++;
-    }
-    return (0);
+	i = 0;
+	while (instruction[i])
+	{
+		if (!is_in_quote(instruction, i))
+		{
+			if (instruction[i] == ';')
+				return (instruction[i]);
+			if (instruction[i] == '&')
+				return (instruction[i]);
+			if (instruction[i] == '|' && instruction[i + 1] == '|')
+				return (instruction[i]);
+		}
+		i++;
+	}
+	return (0);
 }
 
 static char	valid_file_name(char *instruction)
 {
-    int 	i;
-	char 	next_char;
+	int		i;
+	char	next_char;
 
-    i = 0;
-    while (instruction[i])
-    {
-        if (!is_in_quote(instruction, i))
-        {
-            if (instruction[i] == '>' || instruction[i] == '<')
-            {
+	i = 0;
+	while (instruction[i])
+	{
+		if (!is_in_quote(instruction, i))
+		{
+			if (instruction[i] == '>' || instruction[i] == '<')
+			{
 				if (instruction[i + 1] == '>' || instruction[i + 1] == '<')
 					i++;
 				while (instruction[i + 1] == ' ')
 					i++;
 				if (instruction[i + 1] == '\0')
-					return('\n');
+					return ('\n');
 				next_char = instruction[i + 1];
-				if (!ft_isalnum(next_char) && next_char != '|' && next_char != '$')
-					return(next_char);
-            }
-        }
-        i++;
-    }
+				if (!ft_isalnum(next_char) && next_char != '|'
+					&& next_char != '$')
+					return (next_char);
+			}
+		}
+		i++;
+	}
 	return (0);
 }
 
@@ -78,7 +79,6 @@ static char	unclosed_quote_check(char *instruction)
 			in_single_quote = !in_single_quote;
 		ptr++;
 	}
-
 	if (in_single_quote)
 		return ('\'');
 	if (in_double_quote)
@@ -95,21 +95,21 @@ static int	print_syntax_error(char invalid_char)
 		ft_printf("syntax error near unexpected token `newline'\n");
 	else
 		ft_printf("syntax error near unexpected token `%c'\n", invalid_char);
-	return(1);
+	return (1);
 }
 
 int	syntax_error_check(char *instruction)
 {
-    char	c;
+	char	c;
 
-    c = invalid_char_check(instruction);
-    if (c != 0)
-        return print_syntax_error(c);
-    c = valid_file_name(instruction);
-    if (c != 0)
-        return print_syntax_error(c);
-    c = unclosed_quote_check(instruction);
-    if (c != 0)
-        return print_syntax_error(c);
-    return (0);
+	c = invalid_char_check(instruction);
+	if (c != 0)
+		return (print_syntax_error(c));
+	c = valid_file_name(instruction);
+	if (c != 0)
+		return (print_syntax_error(c));
+	c = unclosed_quote_check(instruction);
+	if (c != 0)
+		return (print_syntax_error(c));
+	return (0);
 }

--- a/src/presyntax.c
+++ b/src/presyntax.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 15:12:06 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/15 16:52:13 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/20 14:08:38 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,8 +84,6 @@ int	syntax_error_check(char *instruction)
 	char	c;
 
 	c = 0;
-	remove_extra_spaces(instruction);
-	white_spaces_into_spaces(instruction);
 	c = invalid_char_check(instruction);
 	if (c != 0)
 		return (print_syntax_error(c));


### PR DESCRIPTION
Before this update, presyntax raised and error as soon as an incorrect char was found inside the instruction. Now it will accept those characters as long as they are inside quotes.

I also accepts unclosed quotes inside a quote section.
