### PR TITLE
feat: builtin exec function

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/23 08:45:34 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/23 12:01:02 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -141,9 +141,9 @@ int					execution(t_macro *macro);
 /* execution utils */
 char				**build_cmd_args_array(t_token *cmd_args);
 char				**prepare_child_execution(t_macro *macro, t_cmd *cmd);
-// int					get_exit_code(int status);
-// int					wait_processes(pid_t *pid, int cmds);
-int						wait_processes(pid_t pid);
+int					wait_processes(pid_t pid);
+void 				catch_parent_exit(int *pipe_exit, int *g_exit);
+void 				close_fds(int *pipe_fd, int read_end);
 
 /* validation */
 int					validate_executable(t_macro *macro, t_cmd *cmd);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -113,7 +113,7 @@ char				*expand_envir(char *clean, char *instruction,
 bool				is_builtin(t_token *token);
 bool				is_redir(t_token *token, char *redir_type);
 void				fix_redirections(char *instruction);
-void 				clean_token_quotes(t_token *tokens);
+void				clean_token_quotes(t_token *tokens);
 
 /* list_utils */
 t_token				*init_token(void);
@@ -142,8 +142,8 @@ int					execution(t_macro *macro);
 char				**build_cmd_args_array(t_token *cmd_args);
 char				**prepare_child_execution(t_macro *macro, t_cmd *cmd);
 int					wait_processes(pid_t pid);
-void 				catch_parent_exit(int *pipe_exit, int *g_exit);
-void 				close_fds(int *pipe_fd, int read_end);
+void				catch_parent_exit(int *pipe_exit, int *g_exit);
+void				close_fds(int *pipe_fd, int read_end);
 
 /* validation */
 int					validate_executable(t_macro *macro, t_cmd *cmd);
@@ -156,10 +156,12 @@ char				*get_executable_path(char **paths, char *executable);
 int					open_file(t_token *token);
 
 /* expand */
-char				*get_expanded_instruction(char *instruction, t_macro *macro);
+char				*get_expanded_instruction(char *instruction,
+						t_macro *macro);
 
 /* dup */
-void				dup_file_descriptors(t_macro *macro, t_cmd *cmd, int read_end);
+void				dup_file_descriptors(t_macro *macro, t_cmd *cmd,
+						int read_end);
 
 /* clean utils*/
 char				*get_envir_name(char *str);

--- a/src/dup.c
+++ b/src/dup.c
@@ -16,26 +16,27 @@ extern int	g_exit;
 
 static int	open_last_redir_file(t_token *redir, char *redir_type)
 {
-    t_token	*tmp;
-    t_token	*last_redir = NULL;
-    int		fd;
+	t_token	*tmp;
+	t_token	*last_redir;
+	int		fd;
 
-    tmp = redir;
-    while (tmp)
-    {
-        if (is_redir(tmp, redir_type))
-            last_redir = tmp;
-        tmp = tmp->next;
-    }
-    fd = -1;
-    if (last_redir)
-    {
-        if (last_redir->type == HERE_DOC)
-            fd = ft_atoi(last_redir->value);
-        else
-            fd = open_file(last_redir);
-    }
-    return (fd);
+	last_redir = NULL;
+	tmp = redir;
+	while (tmp)
+	{
+		if (is_redir(tmp, redir_type))
+			last_redir = tmp;
+		tmp = tmp->next;
+	}
+	fd = -1;
+	if (last_redir)
+	{
+		if (last_redir->type == HERE_DOC)
+			fd = ft_atoi(last_redir->value);
+		else
+			fd = open_file(last_redir);
+	}
+	return (fd);
 }
 
 static void	dup_stdout(t_macro *macro, t_cmd *cmd)
@@ -61,7 +62,7 @@ static void	dup_stdout(t_macro *macro, t_cmd *cmd)
 			return ;
 		}
 	}
-	if(macro->pipe_fd[1] != -1)
+	if (macro->pipe_fd[1] != -1)
 		close(macro->pipe_fd[1]);
 }
 
@@ -88,12 +89,12 @@ static void	dup_stdin(t_macro *macro, t_cmd *cmd, int read_end)
 			return ;
 		}
 	}
-	if(macro->pipe_fd[0] != -1)
+	if (macro->pipe_fd[0] != -1)
 		close(macro->pipe_fd[0]);
 }
 
 void	dup_file_descriptors(t_macro *macro, t_cmd *cmd, int read_end)
 {
-		dup_stdout(macro, cmd);
-		dup_stdin(macro, cmd, read_end);
+	dup_stdout(macro, cmd);
+	dup_stdin(macro, cmd, read_end);
 }

--- a/src/dup.c
+++ b/src/dup.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/13 23:24:13 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/22 22:57:06 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/23 12:29:00 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,7 +61,8 @@ static void	dup_stdout(t_macro *macro, t_cmd *cmd)
 			return ;
 		}
 	}
-	close(macro->pipe_fd[1]);
+	if(macro->pipe_fd[1] != -1)
+		close(macro->pipe_fd[1]);
 }
 
 static void	dup_stdin(t_macro *macro, t_cmd *cmd, int read_end)
@@ -87,13 +88,12 @@ static void	dup_stdin(t_macro *macro, t_cmd *cmd, int read_end)
 			return ;
 		}
 	}
-	close(macro->pipe_fd[0]);
+	if(macro->pipe_fd[0] != -1)
+		close(macro->pipe_fd[0]);
 }
-
-
 
 void	dup_file_descriptors(t_macro *macro, t_cmd *cmd, int read_end)
 {
-	dup_stdout(macro, cmd);
-	dup_stdin(macro, cmd, read_end);
+		dup_stdout(macro, cmd);
+		dup_stdin(macro, cmd, read_end);
 }

--- a/src/execution.c
+++ b/src/execution.c
@@ -23,19 +23,19 @@ int	execute_builtin(t_macro *macro, char **cmd_array)
 	return (g_exit);
 }
 
-int execute_single_builtin(t_macro *macro)
+int	execute_single_builtin(t_macro *macro)
 {
-	char **cmd_array;
-	int saved_stdout;
-	int saved_stdin;
+	char	**cmd_array;
+	int		saved_stdout;
+	int		saved_stdin;
 
 	saved_stdout = dup(STDOUT_FILENO);
 	saved_stdin = dup(STDIN_FILENO);
 	cmd_array = build_cmd_args_array(macro->cmds->cmd_arg);
 	if (cmd_array == NULL)
 		return (1);
-	if(validate_redirections(macro->cmds->redir) == -1)
-		return(-1);
+	if (validate_redirections(macro->cmds->redir) == -1)
+		return (-1);
 	dup_file_descriptors(macro, macro->cmds, 0);
 	g_exit = execute_builtin(macro, cmd_array);
 	free_array(&cmd_array);
@@ -43,10 +43,11 @@ int execute_single_builtin(t_macro *macro)
 	dup2(saved_stdin, STDIN_FILENO);
 	close(saved_stdout);
 	close(saved_stdin);
-	return g_exit;
+	return (g_exit);
 }
 
-static void	execute_child_process(t_macro *macro, int index, int read_end, int pipe_exit[2])
+static void	execute_child_process(t_macro *macro, int index, int read_end,
+		int pipe_exit[2])
 {
 	int		i;
 	t_cmd	*cmd;
@@ -57,7 +58,7 @@ static void	execute_child_process(t_macro *macro, int index, int read_end, int p
 	i = 0;
 	while (cmd != NULL && i++ < index)
 		cmd = cmd->next;
-	if(validate_redirections(cmd->redir) == -1)
+	if (validate_redirections(cmd->redir) == -1)
 		exit(g_exit);
 	dup_file_descriptors(macro, cmd, read_end);
 	cmd_array = prepare_child_execution(macro, cmd);
@@ -72,7 +73,6 @@ static void	execute_child_process(t_macro *macro, int index, int read_end, int p
 	}
 	exit(g_exit);
 }
-
 
 static int	execute_cmds(t_macro *macro, int read_end, int pipe_exit[2])
 {
@@ -107,8 +107,8 @@ int	execution(t_macro *macro)
 	int		read_end;
 	int		num_cmds_executed;
 	char	**cmd_array;
-	int	 	pipe_exit[2];
-	int 	i;
+	int		pipe_exit[2];
+	int		i;
 
 	if (macro->num_cmds == 1 && macro->cmds->type == BUILTIN)
 		execute_single_builtin(macro);

--- a/src/execution_utils.c
+++ b/src/execution_utils.c
@@ -6,11 +6,34 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/09 20:03:14 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/23 08:21:45 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/23 12:00:47 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+void close_fds(int *pipe_fd, int read_end)
+{
+    if (pipe_fd[0] != -1)
+    {
+        close(pipe_fd[0]);
+        pipe_fd[0] = -1;
+    }
+    if (pipe_fd[1] != -1)
+    {
+        close(pipe_fd[1]);
+        pipe_fd[1] = -1;
+    }
+	if (read_end > 0)
+        close(read_end);
+}
+
+void catch_parent_exit(int *pipe_exit, int *g_exit)
+{
+    close(pipe_exit[1]);
+    read(pipe_exit[0], g_exit, sizeof(int));
+    close(pipe_exit[0]);
+}
 
 int	wait_processes(pid_t pid)
 {

--- a/src/execution_utils.c
+++ b/src/execution_utils.c
@@ -12,27 +12,27 @@
 
 #include "minishell.h"
 
-void close_fds(int *pipe_fd, int read_end)
+void	close_fds(int *pipe_fd, int read_end)
 {
-    if (pipe_fd[0] != -1)
-    {
-        close(pipe_fd[0]);
-        pipe_fd[0] = -1;
-    }
-    if (pipe_fd[1] != -1)
-    {
-        close(pipe_fd[1]);
-        pipe_fd[1] = -1;
-    }
+	if (pipe_fd[0] != -1)
+	{
+		close(pipe_fd[0]);
+		pipe_fd[0] = -1;
+	}
+	if (pipe_fd[1] != -1)
+	{
+		close(pipe_fd[1]);
+		pipe_fd[1] = -1;
+	}
 	if (read_end > 0)
-        close(read_end);
+		close(read_end);
 }
 
-void catch_parent_exit(int *pipe_exit, int *g_exit)
+void	catch_parent_exit(int *pipe_exit, int *g_exit)
 {
-    close(pipe_exit[1]);
-    read(pipe_exit[0], g_exit, sizeof(int));
-    close(pipe_exit[0]);
+	close(pipe_exit[1]);
+	read(pipe_exit[0], g_exit, sizeof(int));
+	close(pipe_exit[0]);
 }
 
 int	wait_processes(pid_t pid)
@@ -43,7 +43,7 @@ int	wait_processes(pid_t pid)
 	exit_code = 0;
 	waitpid(pid, &status, 0);
 	if (WIFEXITED(status))
-		exit_code = WEXITSTATUS(status); 
+		exit_code = WEXITSTATUS(status);
 	else if (WIFSIGNALED(status))
 		exit_code = 128 + WTERMSIG(status);
 	return (exit_code);
@@ -76,7 +76,6 @@ char	**build_cmd_args_array(t_token *cmd_args)
 	return (cmd_array);
 }
 
-
 char	**prepare_child_execution(t_macro *macro, t_cmd *cmd)
 {
 	char	**cmd_array;
@@ -88,4 +87,3 @@ char	**prepare_child_execution(t_macro *macro, t_cmd *cmd)
 		exit(errno);
 	return (cmd_array);
 }
-

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/23 08:27:25 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/23 11:52:28 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -96,7 +96,6 @@ int	main(int argc, char **argv, char **envp)
 			continue ;
 		if (line[0] != '\0')
 			add_history(line);
-		// FALTA FUNCION AQUI PARA AÑADIR HISTORIAL EN macro->history
 		if (syntax_error_check(line))
 		{
 			free(line);

--- a/src/main.c
+++ b/src/main.c
@@ -103,7 +103,7 @@ int	main(int argc, char **argv, char **envp)
 		}
 		macro->instruction = line;
 		tokenizer(macro);
-		//print_tokens(macro->tokens);
+		// print_tokens(macro->tokens);
 		macro->cmds = parsing(macro);
 		execution(macro);
 	}


### PR DESCRIPTION
Added a specific function to handle when there is only one command, it's a builtin and it has redirections. Before redirections were not considered.

To make it work properly, we shall dup redirections as usual, but later restore again the original `STDIN` and `STDOUT`, we run it in the parent process.