### PR TITLE
feat: promote retokens

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/23 12:01:02 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/23 13:18:35 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -193,8 +193,7 @@ int					ft_strchr_i(const char *s, int c);
 char				**ft_replace_matrix_row(char ***big, char **small, int n);
 void				ft_unset(t_macro *macro);
 int					var_in_env(char *argv, char **env, int ij[2]);
-int					select_and_run_builtin(char *cmd, char **args,
-						t_macro *macro);
+int					select_and_run_builtin(char *cmd, char **args, t_macro *macro);
 bool				check_builtin(char *real_cmd);
 char				*grab_env(char *var, char **env, int n);
 char				**fix_env(char *var, char *value, char **env, int n);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/25 15:11:00 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 15:29:06 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -104,6 +104,7 @@ t_list				*split_args_by_quotes(char *ins);
 
 /* tokenizer_expand */
 t_token				*expand_arg_tokens(t_macro *macro);
+void ensure_at_least_one_cmd(t_token **tokens);
 
 /* tokenizer_utils */
 bool				is_inside_single_quotes(const char *str, int index);
@@ -114,6 +115,7 @@ bool				is_builtin(t_token *token);
 bool				is_redir(t_token *token, char *redir_type);
 void				fix_redirections(char *instruction);
 void				clean_token_quotes(t_token *tokens);
+
 
 /* list_utils */
 t_token				*init_token(void);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/23 13:18:35 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 15:11:00 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -128,6 +128,8 @@ void				print_cmds(t_cmd *cmds);
 char				*enum_to_char(t_type type);
 bool				is_last_of_type(t_token *tokens, t_type type);
 int					tokens_size(t_token *tokens);
+void 				remove_token(t_token **tokens, t_token *token);
+t_token				*remove_empty_envir_tokens(t_macro *macro);
 
 /* parsing */
 t_cmd				*parsing(t_macro *macro);

--- a/src/execution.c
+++ b/src/execution.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:23:53 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/23 12:33:42 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/24 22:06:23 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,6 +62,8 @@ static void	execute_child_process(t_macro *macro, int index, int read_end,
 		exit(g_exit);
 	dup_file_descriptors(macro, cmd, read_end);
 	cmd_array = prepare_child_execution(macro, cmd);
+	if (!cmd_array || !cmd_array[0])
+        exit(errno);
 	if (cmd->type == BUILTIN)
 		g_exit = execute_builtin(macro, cmd_array);
 	else

--- a/src/execution_utils.c
+++ b/src/execution_utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/09 20:03:14 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/23 12:00:47 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/24 22:06:51 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,6 +56,8 @@ char	**build_cmd_args_array(t_token *cmd_args)
 	int		i;
 
 	tmp = cmd_args;
+	if(!cmd_args)
+		return (NULL);
 	cmd_array = (char **)malloc(sizeof(char *) * (tokens_size(cmd_args) + 1));
 	if (!cmd_array)
 		return (NULL);

--- a/src/expand.c
+++ b/src/expand.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/21 18:52:58 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/22 22:17:44 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 12:13:57 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,9 +63,7 @@ char	*build_expanded_instruction(char *clean, char *ins, t_macro *macro)
 		else
 			clean[j++] = ins[i++];
 	}
-	clean[j] = '\0';
 	free(exit_str);
-	    // Debug prints
 	return (clean);
 }
 
@@ -115,6 +113,8 @@ char	*get_expanded_instruction(char *ins, t_macro *macro)
 	envir_len = expanded_envir_len(ins, macro);
 	total_len = envir_len + ft_strlen(ins);
 	clean = ft_calloc(1, sizeof(char) * total_len + 1);
+	if(!clean)
+		return(NULL);
 	clean = build_expanded_instruction(clean, ins, macro);
 	clean[total_len] = '\0';
 	return (clean);

--- a/src/list_utils.c
+++ b/src/list_utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/03 21:43:43 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/09 20:09:40 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 15:05:25 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,6 +31,28 @@ void	token_add_back(t_token **tokens, t_token *new)
 		*tokens = new;
 	else
 		(last_token(*tokens))->next = new;
+}
+
+void remove_token(t_token **tokens, t_token *token)
+{
+    t_token *current = *tokens;
+    t_token *prev = NULL;
+
+    while (current != NULL)
+    {
+        if (current == token)
+        {
+            if (prev != NULL)
+                prev->next = current->next;
+            else
+                *tokens = current->next;
+            free(current->value);
+            free(current);
+            return;
+        }
+        prev = current;
+        current = current->next;
+    }
 }
 
 t_token	*last_token(t_token *token)

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/23 11:52:28 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/23 13:24:55 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -103,7 +103,9 @@ int	main(int argc, char **argv, char **envp)
 		}
 		macro->instruction = line;
 		tokenizer(macro);
-		// print_tokens(macro->tokens);
+		if(ft_strcmp(macro->tokens->value, "") == 0)
+			continue;
+		//print_tokens(macro->tokens);
 		macro->cmds = parsing(macro);
 		execution(macro);
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/23 13:24:55 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/24 21:06:04 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -92,8 +92,11 @@ int	main(int argc, char **argv, char **envp)
 			printf("Ctrl+D exits\n");
 			break ;
 		}
-		if (ft_strcmp(line, "") == 0)
+		if (ft_str_empty(line))
+		{
+			free(line);
 			continue ;
+		}
 		if (line[0] != '\0')
 			add_history(line);
 		if (syntax_error_check(line))

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/24 21:06:04 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 15:12:45 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -106,8 +106,6 @@ int	main(int argc, char **argv, char **envp)
 		}
 		macro->instruction = line;
 		tokenizer(macro);
-		if(ft_strcmp(macro->tokens->value, "") == 0)
-			continue;
 		//print_tokens(macro->tokens);
 		macro->cmds = parsing(macro);
 		execution(macro);

--- a/src/parsing.c
+++ b/src/parsing.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 09:53:20 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/22 22:55:17 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/24 21:04:30 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -105,7 +105,12 @@ static char	parsing_error_check(t_token *tokens)
 	tmp = tokens;
 	if (tmp && tmp->type == PIPE)
 		c = '|';
-	tmp = last_token(tokens);
+	while (tmp && tmp->next)
+	{
+		if (tmp->type == PIPE && tmp->next->type == PIPE)
+			c = '|';
+		tmp = tmp->next;
+	}
 	if (tmp && tmp->type == PIPE)
 		c = '|';
 	if (c != 0)

--- a/src/parsing.c
+++ b/src/parsing.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 09:53:20 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/24 21:04:30 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/24 21:50:27 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -85,7 +85,8 @@ static t_cmd	*parse_tokens(t_token *tokens, int *n)
 			return (NULL);
 		cmd->n = (*n)++;
 		cmd->cmd_arg = parse_cmd_arg_tokens(tmp);
-		cmd->type = cmd->cmd_arg->type;
+		if(cmd->cmd_arg)
+			cmd->type = cmd->cmd_arg->type;
 		cmd->redir = parse_redir_tokens(tmp);
 		cmd_add_back(&cmds, cmd);
 		while (tmp && tmp->type != PIPE)

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/03 21:24:44 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/23 08:26:07 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 15:13:34 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -98,13 +98,18 @@ void	tokenizer(t_macro *macro)
 		free(lexemes);
 		return ;
 	}
+	free(lexemes);
+	macro->tokens = remove_empty_envir_tokens(macro);
+	if (!macro->tokens)
+	{
+		free_tokens(&macro->tokens);
+		return ;
+	}
 	macro->tokens = expand_arg_tokens(macro);
 	if (!macro->tokens)
 	{
 		free_tokens(&macro->tokens);
-		free(lexemes);
 		return ;
 	}
 	clean_token_quotes(macro->tokens);
-	free(lexemes);
 }

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/03 21:24:44 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/25 15:13:34 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 15:44:36 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -100,6 +100,7 @@ void	tokenizer(t_macro *macro)
 	}
 	free(lexemes);
 	macro->tokens = remove_empty_envir_tokens(macro);
+	ensure_at_least_one_cmd(&macro->tokens);
 	if (!macro->tokens)
 	{
 		free_tokens(&macro->tokens);

--- a/src/tokenizer_expand.c
+++ b/src/tokenizer_expand.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/22 17:45:23 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/22 17:46:09 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/23 13:21:31 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,8 +84,12 @@ t_token	*expand_arg_tokens(t_macro *macro)
 		if (ft_strchr(tokens->value, '$'))
 		{
 			expanded = get_expanded_instruction(tokens->value, macro);
-			if (!expanded)
-				return (NULL);
+            if (!expanded || *expanded == '\0')
+            {
+                tokens->value = ft_strdup("");
+                if (!tokens->value)
+                    return (NULL);
+            }
 			if (ft_strchr("\"", tokens->value[0]))
 				tokens->value = expanded;
 			else
@@ -98,5 +102,14 @@ t_token	*expand_arg_tokens(t_macro *macro)
 		}
 		tokens = tokens->next;
 	}
+
+	// Promotion logic
+    if (macro->tokens && macro->tokens->value[0] == '\0' && macro->tokens->next)
+    {
+        t_token *second_token = macro->tokens->next;
+        macro->tokens->value = second_token->value;
+        macro->tokens->next = second_token->next;
+        free(second_token);
+    }
 	return (macro->tokens);
 }

--- a/src/tokenizer_expand.c
+++ b/src/tokenizer_expand.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/22 17:45:23 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/25 15:09:50 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 15:43:44 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -121,4 +121,33 @@ t_token	*remove_empty_envir_tokens(t_macro *macro)
 		tokens = tokens->next;
 	}
 	return (macro->tokens);
+}
+
+void ensure_at_least_one_cmd(t_token **tokens)
+{
+    t_token *current = *tokens;
+    int cmd_found = 0; 
+	int first_token = 1;
+
+    while (current)
+	{
+        if (first_token || current->type == PIPE)
+        {
+            cmd_found = 0;
+            first_token = 0;
+        }
+        if (is_redir(current, "infile") || is_redir(current, "outfile"))
+		{
+            current = current->next;
+            continue; 
+        }
+		if(current->type == CMD)
+			cmd_found = 1;
+        if (!cmd_found &&  current->type == ARG)
+		{
+            current->type = CMD; 
+            cmd_found = 1; 
+        }   
+        current = current->next;
+    }
 }

--- a/src/tokenizer_expand.c
+++ b/src/tokenizer_expand.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/22 17:45:23 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/23 13:21:31 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 15:09:50 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -85,11 +85,7 @@ t_token	*expand_arg_tokens(t_macro *macro)
 		{
 			expanded = get_expanded_instruction(tokens->value, macro);
             if (!expanded || *expanded == '\0')
-            {
-                tokens->value = ft_strdup("");
-                if (!tokens->value)
-                    return (NULL);
-            }
+				return(NULL);
 			if (ft_strchr("\"", tokens->value[0]))
 				tokens->value = expanded;
 			else
@@ -102,14 +98,27 @@ t_token	*expand_arg_tokens(t_macro *macro)
 		}
 		tokens = tokens->next;
 	}
+	return (macro->tokens);
+}
 
-	// Promotion logic
-    if (macro->tokens && macro->tokens->value[0] == '\0' && macro->tokens->next)
-    {
-        t_token *second_token = macro->tokens->next;
-        macro->tokens->value = second_token->value;
-        macro->tokens->next = second_token->next;
-        free(second_token);
-    }
+t_token	*remove_empty_envir_tokens(t_macro *macro)
+{
+	t_token	*tokens;
+	t_token	*retokens;
+	char	*expanded;
+
+	tokens = macro->tokens;
+	while (tokens)
+	{
+		if (ft_strchr(tokens->value, '$'))
+		{
+			expanded = get_expanded_instruction(tokens->value, macro);
+			if(!expanded)
+				return(NULL);
+            if (*expanded == '\0')
+				remove_token(&macro->tokens, tokens);
+		}
+		tokens = tokens->next;
+	}
 	return (macro->tokens);
 }


### PR DESCRIPTION
This PR tries to handle errors related to environmental variables that have empty values or they just don't exist on the system. The expansion of this envirs returns a null character. 

I order to avoid errors in the retokenization, the new implementation first check is the expansion is empty and remove that node from the tokens list. Later continue with the nodes that do have actual content ant retokenize or handle it accordingly.

In all cases, we do one last check to ensure that all commands have a `CMD` node as the first node of the section.