### PR TITLE
Fix segfault when parsing returns NULL, the code is NULL-protected now

### DIFF
--- a/src/execution.c
+++ b/src/execution.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   execution.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:23:53 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/24 22:06:23 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 21:23:13 by dbejar-s         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -112,6 +112,8 @@ int	execution(t_macro *macro)
 	int		pipe_exit[2];
 	int		i;
 
+	if (macro->cmds == NULL)
+		return (0);
 	if (macro->num_cmds == 1 && macro->cmds->type == BUILTIN)
 		execute_single_builtin(macro);
 	else

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/24 21:06:04 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 21:25:11 by dbejar-s         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -110,7 +110,13 @@ int	main(int argc, char **argv, char **envp)
 			continue;
 		//print_tokens(macro->tokens);
 		macro->cmds = parsing(macro);
+		if (macro->cmds == NULL)
+		{
+			free(line);
+			continue ;
+		}
 		execution(macro);
+		//VALORAR METER AQUI UN CLEAN_MACRO ANTES DE QUE VUELVA EL LOOP: se puede limpiar todo menos el env. No lo quiero meter ahora por no hacer doubles frees, pero probablemente haya que meterlo por temas de leaks.
 	}
 	exit(g_exit);
 }


### PR DESCRIPTION
I don't know if the exit code is correct in case the parsing returns NULL. I need to check that, but I haven't reproduced the segfault again with the protection included here.