### PR TITLE
fix: restore here doc function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/08/01 15:11:43 by pmarkaid          #+#    #+#              #
-#    Updated: 2024/08/23 08:53:16 by pmarkaid         ###   ########.fr        #
+#    Updated: 2024/08/26 11:39:00 by pmarkaid         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -54,7 +54,7 @@ TEST_OBJS = $(TEST_SRCS:.c=.o)
 TEST_NAME = tests_runner
 
 CC = cc 
-CFLAGS = -Werror -Wextra -g
+CFLAGS = -Wall -Werror -Wextra -g
 DEBUG_FLAGS = -g
 
 # External Libraries

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/23 13:18:35 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 17:52:18 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -133,7 +133,7 @@ int					tokens_size(t_token *tokens);
 t_cmd				*parsing(t_macro *macro);
 
 /* parsing utils */
-void				handle_here_doc(t_cmd *cmds);
+void				handle_here_doc(t_token *tokens);
 
 /* execution */
 int					execution(t_macro *macro);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/26 13:42:46 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/26 14:29:49 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -137,7 +137,8 @@ t_token				*remove_empty_envir_tokens(t_macro *macro);
 t_cmd				*parsing(t_macro *macro);
 
 /* parsing utils */
-void				handle_here_doc(t_token *tokens);
+void				handle_here_doc(t_cmd *cmds);
+void 				close_here_doc_not_needed(t_token *tokens);
 
 /* execution */
 int					execution(t_macro *macro);

--- a/src/dup.c
+++ b/src/dup.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/13 23:24:13 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/23 12:29:00 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/26 14:54:18 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,12 +29,17 @@ static int	open_last_redir_file(t_token *redir, char *redir_type)
 		tmp = tmp->next;
 	}
 	fd = -1;
-	if (last_redir)
+	tmp = redir;
+	while (tmp)
 	{
-		if (last_redir->type == HERE_DOC)
-			fd = ft_atoi(last_redir->value);
-		else
-			fd = open_file(last_redir);
+		if (tmp == last_redir)
+		{
+			if (last_redir->type == HERE_DOC)
+				fd = ft_atoi(last_redir->value);
+			else
+				fd = open_file(last_redir);
+		}
+		tmp = tmp->next;
 	}
 	return (fd);
 }

--- a/src/execution.c
+++ b/src/execution.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:23:53 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/26 13:43:04 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/26 15:03:17 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,7 +58,6 @@ static void	execute_child_process(t_macro *macro, int index, int read_end,
 	i = 0;
 	while (cmd != NULL && i++ < index)
 		cmd = cmd->next;
-	handle_here_doc(macro->tokens);
 	if (validate_redirections(cmd->redir) == -1)
 		exit(g_exit);
 	dup_file_descriptors(macro, cmd, read_end);

--- a/src/execution.c
+++ b/src/execution.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:23:53 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/25 17:51:20 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/26 11:53:54 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,6 +58,7 @@ static void	execute_child_process(t_macro *macro, int index, int read_end,
 	i = 0;
 	while (cmd != NULL && i++ < index)
 		cmd = cmd->next;
+	handle_here_doc(macro->tokens);
 	if (validate_redirections(cmd->redir) == -1)
 		exit(g_exit);
 	dup_file_descriptors(macro, cmd, read_end);
@@ -108,11 +109,9 @@ int	execution(t_macro *macro)
 {
 	int		read_end;
 	int		num_cmds_executed;
-	char	**cmd_array;
 	int		pipe_exit[2];
 	int		i;
 
-	handle_here_doc(macro->tokens);
 	if (macro->num_cmds == 1 && macro->cmds->type == BUILTIN)
 		execute_single_builtin(macro);
 	else

--- a/src/execution.c
+++ b/src/execution.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:23:53 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/24 22:06:23 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 17:51:20 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -112,6 +112,7 @@ int	execution(t_macro *macro)
 	int		pipe_exit[2];
 	int		i;
 
+	handle_here_doc(macro->tokens);
 	if (macro->num_cmds == 1 && macro->cmds->type == BUILTIN)
 		execute_single_builtin(macro);
 	else

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/24 21:06:04 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 17:31:25 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -108,7 +108,7 @@ int	main(int argc, char **argv, char **envp)
 		tokenizer(macro);
 		if(ft_strcmp(macro->tokens->value, "") == 0)
 			continue;
-		//print_tokens(macro->tokens);
+		print_tokens(macro->tokens);
 		macro->cmds = parsing(macro);
 		execution(macro);
 	}

--- a/src/parsing.c
+++ b/src/parsing.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 09:53:20 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/24 21:50:27 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 17:38:21 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -139,6 +139,5 @@ t_cmd	*parsing(t_macro *macro)
 	if (!cmds)
 		return (NULL);
 	macro->num_cmds = n - 1;
-	handle_here_doc(cmds);
 	return (cmds);
 }

--- a/src/parsing.c
+++ b/src/parsing.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 09:53:20 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/25 17:38:21 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/26 14:51:09 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -139,5 +139,6 @@ t_cmd	*parsing(t_macro *macro)
 	if (!cmds)
 		return (NULL);
 	macro->num_cmds = n - 1;
+	handle_here_doc(cmds);
 	return (cmds);
 }

--- a/src/parsing_utils.c
+++ b/src/parsing_utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/14 10:42:44 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/23 08:40:38 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/25 17:51:02 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,26 +36,20 @@ static int	read_here_doc(t_token *token)
 	return (pipe_fd[0]);
 }
 
-void	handle_here_doc(t_cmd *cmds)
+void	handle_here_doc(t_token *tokens)
 {
 	t_token	*token;
-	t_cmd	*cmd;
 	int		fd;
 
-	cmd = cmds;
-	while (cmd)
+	token = tokens;
+	while (token)
 	{
-		token = cmd->redir;
-		while (token)
+		if (token->type == HERE_DOC)
 		{
-			if (token->type == HERE_DOC)
-			{
-				fd = read_here_doc(token);
-				free(token->value);
-				token->value = ft_itoa(fd);
-			}
-			token = token->next;
+			fd = read_here_doc(token);
+			free(token->value);
+			token->value = ft_itoa(fd);
 		}
-		cmd = cmd->next;
+		token = token->next;
 	}
 }

--- a/src/parsing_utils.c
+++ b/src/parsing_utils.c
@@ -6,18 +6,19 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/14 10:42:44 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/26 11:32:18 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/26 15:02:55 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static int close_here_doc_not_needed(t_token *tokens)
+void close_here_doc_not_needed(t_token *tokens)
 {
 	t_token	*tmp;
 	t_token *last;
 	int		fd;
 
+	last = NULL;
 	tmp = tokens;
 	while (tmp && is_redir(tmp, "input"))
 	{
@@ -34,7 +35,6 @@ static int close_here_doc_not_needed(t_token *tokens)
 		}
 		tmp = tmp->next;
 	}
-	return (0);
 }
 
 static int	read_here_doc(t_token *token)
@@ -61,21 +61,29 @@ static int	read_here_doc(t_token *token)
 	return (pipe_fd[0]);
 }
 
-void	handle_here_doc(t_token *tokens)
+void	handle_here_doc(t_cmd *cmds)
 {
 	t_token	*token;
+	t_cmd	*cmd;
 	int		fd;
 
-	token = tokens;
-	while (token)
+	cmd = cmds;
+	while (cmd)
 	{
-		if (token->type == HERE_DOC)
+		if(cmd->redir)
 		{
-			fd = read_here_doc(token);
-			free(token->value);
-			token->value = ft_itoa(fd);
+			token = cmd->redir;
+			while (token)
+			{
+				if (token->type == HERE_DOC)
+				{
+					fd = read_here_doc(token);
+					free(token->value);
+					token->value = ft_itoa(fd);
+				}
+				token = token->next;
+			}
 		}
-		token = token->next;
+		cmd = cmd->next;
 	}
-	close_here_doc_not_needed(tokens);
 }

--- a/src/parsing_utils.c
+++ b/src/parsing_utils.c
@@ -6,11 +6,36 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/14 10:42:44 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/25 17:51:02 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/26 11:32:18 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+static int close_here_doc_not_needed(t_token *tokens)
+{
+	t_token	*tmp;
+	t_token *last;
+	int		fd;
+
+	tmp = tokens;
+	while (tmp && is_redir(tmp, "input"))
+	{
+		last = tmp;
+		tmp = tmp->next;
+	}
+	tmp = tokens;
+	while (tmp)
+	{
+		if (tmp->type == HERE_DOC && tmp != last)
+		{
+			fd = ft_atoi(tmp->value);
+			close(fd);
+		}
+		tmp = tmp->next;
+	}
+	return (0);
+}
 
 static int	read_here_doc(t_token *token)
 {
@@ -52,4 +77,5 @@ void	handle_here_doc(t_token *tokens)
 		}
 		token = token->next;
 	}
+	close_here_doc_not_needed(tokens);
 }

--- a/src/tokenizer_expand.c
+++ b/src/tokenizer_expand.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/22 17:45:23 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/25 15:43:44 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/26 13:44:54 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -104,7 +104,6 @@ t_token	*expand_arg_tokens(t_macro *macro)
 t_token	*remove_empty_envir_tokens(t_macro *macro)
 {
 	t_token	*tokens;
-	t_token	*retokens;
 	char	*expanded;
 
 	tokens = macro->tokens;

--- a/src/validation.c
+++ b/src/validation.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:35:57 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/22 23:21:04 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/26 15:00:01 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,10 @@ int	validate_redirections(t_token *redir)
         if (is_redir(tmp, "input") || is_redir(tmp, "output"))
         {
             if (tmp->type == HERE_DOC)
+			{
+				tmp = tmp->next;
                 continue;
+			}
             else
             {
                 fd = open_file(tmp);
@@ -36,6 +39,7 @@ int	validate_redirections(t_token *redir)
         }
         tmp = tmp->next;
     }
+	close_here_doc_not_needed(redir);
     return (0);
 }
 

--- a/src/validation_utils.c
+++ b/src/validation_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   validation_utils.c                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/13 23:25:19 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/25 23:07:34 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/26 13:44:26 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,7 @@ int	open_file(t_token *token)
 {
 	int	fd;
 
+	fd = -1;
 	if (token->type == INRED)
 		fd = open(token->value, O_RDONLY);
 	else if (token->type == OUTRED)


### PR DESCRIPTION
After changing the redir tokens back to only one token list, here doc broke. This update fixes some problems and adds a new function to close all here_doc that are not needed (i.e., is not the last input source).