### PR TITLE
feature: correctly use outside quotes to evaluate expansion

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/26 16:00:07 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/26 21:07:30 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -104,20 +104,15 @@ t_list				*split_args_by_quotes(char *ins);
 
 /* tokenizer_expand */
 t_token				*expand_arg_tokens(t_macro *macro);
-void ensure_at_least_one_cmd(t_token **tokens);
+void				ensure_at_least_one_cmd(t_token **tokens);
 
 /* tokenizer_utils */
-bool				is_inside_single_quotes(const char *str, int index);
-bool				is_inside_double_quotes(char *str, int index);
-char				*expand_envir(char *clean, char *instruction,
-						t_macro *macro);
+char				*expand_envir(char *clean, char *instruction, t_macro *macro);
 bool				is_builtin(t_token *token);
 bool				is_redir(t_token *token, char *redir_type);
 void				fix_redirections(char *instruction);
 void				clean_token_quotes(t_token *tokens);
 char				*clean_quotes(char *str);
-
-
 
 /* list_utils */
 t_token				*init_token(void);
@@ -132,7 +127,7 @@ void				print_cmds(t_cmd *cmds);
 char				*enum_to_char(t_type type);
 bool				is_last_of_type(t_token *tokens, t_type type);
 int					tokens_size(t_token *tokens);
-void 				remove_token(t_token **tokens, t_token *token);
+void				remove_token(t_token **tokens, t_token *token);
 t_token				*remove_empty_envir_tokens(t_macro *macro);
 
 /* parsing */
@@ -140,7 +135,7 @@ t_cmd				*parsing(t_macro *macro);
 
 /* parsing utils */
 void				handle_here_doc(t_cmd *cmds, t_macro *macro);
-void 				close_here_doc_not_needed(t_token *tokens);
+void				close_here_doc_not_needed(t_token *tokens);
 
 /* execution */
 int					execution(t_macro *macro);
@@ -200,7 +195,8 @@ int					ft_strchr_i(const char *s, int c);
 char				**ft_replace_matrix_row(char ***big, char **small, int n);
 void				ft_unset(t_macro *macro);
 int					var_in_env(char *argv, char **env, int ij[2]);
-int					select_and_run_builtin(char *cmd, char **args, t_macro *macro);
+int					select_and_run_builtin(char *cmd, char **args,
+						t_macro *macro);
 bool				check_builtin(char *real_cmd);
 char				*grab_env(char *var, char **env, int n);
 char				**fix_env(char *var, char *value, char **env, int n);

--- a/src/expand.c
+++ b/src/expand.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   expand.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/21 18:52:58 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/25 21:54:10 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/26 21:06:19 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,11 +34,10 @@ int	expand_variable(char *clean, int j, char *ins, int i, t_macro *macro)
 	return (i);
 }
 
-
 char	*build_expanded_instruction(char *clean, char *ins, t_macro *macro)
 {
-	int	i;
-	int	j;
+	int		i;
+	int		j;
 	char	*exit_str;
 
 	i = 0;
@@ -46,12 +45,12 @@ char	*build_expanded_instruction(char *clean, char *ins, t_macro *macro)
 	exit_str = ft_itoa(g_exit);
 	while (ins[i])
 	{
-		if(ins[i] == '$' && (ins[i + 1] == '\0' || ft_isdelim(ins[i + 1])))
+		if (ins[i] == '$' && (ins[i + 1] == '\0' || ft_isdelim(ins[i + 1])))
 			clean[j++] = ins[i++];
-		else if(ft_strlen(ins) > 2 && ins[i] == '$' && ins[i + 1] != '\0' && ins[i + 1] == '"')
+		else if (ft_strlen(ins) > 2 && ins[i] == '$' && ins[i + 1] != '\0' && (ft_isquote(ins[i + 1])))
 		{
 			clean[j++] = ins[i++];
-		}	
+		}
 		else if (ins[i] == '$' && envir_must_be_expanded(ins, i))
 		{
 			i++;
@@ -63,8 +62,8 @@ char	*build_expanded_instruction(char *clean, char *ins, t_macro *macro)
 			}
 			else
 			{
-			i = expand_variable(clean, j, ins, i, macro);
-			j += ft_strlen(&clean[j]);
+				i = expand_variable(clean, j, ins, i, macro);
+				j += ft_strlen(&clean[j]);
 			}
 		}
 		else
@@ -87,7 +86,7 @@ size_t	expanded_envir_len(char *ins, t_macro *macro)
 	{
 		if (ins[i] == '$' && (ins[i + 1] == '\0' || ft_isdelim(ins[i + 1])))
 			i++;
-		else if(ft_strlen(ins) > 2 && ins[i] == '$' && ins[i + 1] != '\0' && ins[i + 1] == '"')
+		else if (ft_strlen(ins) > 2 && ins[i] == '$' && ins[i + 1] != '\0' && ins[i + 1] == '"')
 		{
 			i++;
 			envir_len = 1;
@@ -95,7 +94,7 @@ size_t	expanded_envir_len(char *ins, t_macro *macro)
 		else if (ins[i] == '$' && envir_must_be_expanded(ins, i))
 		{
 			i++;
-			if(ins[i] == '?')
+			if (ins[i] == '?')
 			{
 				i++;
 				envir_len += ft_strlen(ft_itoa(g_exit));
@@ -127,10 +126,10 @@ char	*get_expanded_instruction(char *ins, t_macro *macro)
 
 	envir_len = expanded_envir_len(ins, macro);
 	total_len = envir_len + ft_strlen(ins);
-	//printf("total_len: %zu\n", total_len);
+	// printf("total_len: %zu\n", total_len);
 	clean = ft_calloc(1, sizeof(char) * total_len + 1);
-	if(!clean)
-		return(NULL);
+	if (!clean)
+		return (NULL);
 	clean = build_expanded_instruction(clean, ins, macro);
 	clean[total_len] = '\0';
 	return (clean);

--- a/src/expand_utils.c
+++ b/src/expand_utils.c
@@ -6,35 +6,35 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/22 20:53:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/22 20:55:07 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/26 21:07:21 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-bool	is_inside_double_quotes(char *str, int index)
+bool	envir_must_be_expanded(char *str, int index)
 {
+	bool	inside_single_quotes;
 	bool	inside_double_quotes;
 	int		i;
 
+	inside_single_quotes = false;
 	inside_double_quotes = false;
 	i = 0;
-	while (i <= index && str[i] != '\0')
+	while (i < index && str[i] != '\0')
 	{
-		if (str[i] == '\"')
+		if (str[i] == '\'' && !inside_double_quotes)
+			inside_single_quotes = !inside_single_quotes;
+		else if (str[i] == '\"' && !inside_single_quotes)
 			inside_double_quotes = !inside_double_quotes;
 		i++;
 	}
-	return (inside_double_quotes);
-}
-
-bool	envir_must_be_expanded(char *str, int index)
-{
-	if (!is_in_quote(str, index))
+	if (inside_single_quotes)
+		return (false);
+	else if (inside_double_quotes)
 		return (true);
-	if (is_inside_double_quotes(str, index))
+	else
 		return (true);
-	return (false);
 }
 
 bool	is_in_quote(char *str, int index)


### PR DESCRIPTION
Fixed some of the errors found with expansions inside quotes.

I now consider the outer quote as the ruler to evaluate if we expand or not, nos just if the `$` is inside double or single quotes.

Also, I fixed an error that only evaluates `$` followed by double quote and add also the single quote as an option. This fix dollar expanding to `/bin/bash`