### PR TITLE
fix: leaks in tokenizer

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/28 12:08:45 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/28 14:31:32 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -177,6 +177,7 @@ bool				envir_must_be_expanded(char *instruction, int index);
 bool				is_in_quote(char *str, int index);
 
 /* free */
+void				free_string(char **str);
 void				free_array(char ***array);
 void				free_tokens(t_token **tokens);
 void 				free_ins(t_macro *macro);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/28 14:23:10 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/28 15:00:02 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -139,8 +139,11 @@ static char	*create_path(t_macro *macro)
 		path = ft_strdup("minishell:/$ ");
 	else if (in_home(macro))
 		path = ft_strdup("minishell:~$ ");
-	else if (upper_than_home(macro) != NULL)
+	else if (upper_than_home(macro) != NULL) //there is a malloc in this test, not good for leaks
+	{
 		path = upper_than_home(macro);
+		free(macro->m_pwd);
+	}
 	else
 	{
 		tmp = ft_strjoin("minishell:", macro->m_pwd, NULL);
@@ -203,7 +206,7 @@ int	main(int argc, char **argv, char **envp)
 			free(line);
 			continue ;
 		}
-		execution(macro);
+		//execution(macro);
 		free_ins(macro);
 	}
 	free_macro(macro);

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/03 21:24:44 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/25 15:44:36 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/28 14:45:55 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -95,10 +95,11 @@ void	tokenizer(t_macro *macro)
 	macro->tokens = identify_tokens(lexemes);
 	if (!macro->tokens)
 	{
-		free(lexemes);
+		ft_lstclear(&lexemes, ft_del);
 		return ;
 	}
-	free(lexemes);
+	ft_lstclear(&lexemes, ft_del);
+	lexemes = NULL;
 	macro->tokens = remove_empty_envir_tokens(macro);
 	ensure_at_least_one_cmd(&macro->tokens);
 	if (!macro->tokens)


### PR DESCRIPTION
Fix some leaks in tokenizer. Still there is another one

Another leak is in the prompt creation step:

```
	else if (upper_than_home(macro) != NULL)  //there is a malloc in this test, not good for leaks
	{
		path = upper_than_home(macro);
		free(macro->m_pwd);
	}
```

the upper_than_home shall be refactored so is not handled this way. Maybe just evaluate the NULL inside the las else if or something