### PR TITLE
chore: Update minishell.h, free.c, main.c, and main_utils.c

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/28 12:08:45 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/28 16:17:44 by dbejar-s         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -210,6 +210,7 @@ int					ft_unset2(char **args, t_macro *macro);
 int					ft_export2(char **args, t_macro *macro);
 int					ft_echo2(char **args);
 int					ft_cd2(char **args, t_macro *macro);
+char				*ft_strjoin3(const char *s1, const char *s2, const char *s3);
 
 /* error */
 int					error_msg(char *msg, int exit_code);

--- a/src/free.c
+++ b/src/free.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   free.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/04 13:02:09 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/28 12:17:19 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/28 16:19:47 by dbejar-s         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -76,7 +76,6 @@ void	free_ins(t_macro *macro)
 	free_tokens(&macro->tokens);
 	free_cmds(&macro->cmds);
 	macro->num_cmds = 0;
-	close_fds(macro->pipe_fd, 0);
 }
 
 void	free_macro(t_macro *macro)

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/28 14:23:10 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/28 16:19:03 by dbejar-s         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -117,8 +117,7 @@ static char	*upper_than_home(t_macro *macro)
 	if (ft_strncmp(macro->m_pwd, home, len) == 0)
 	{
 		tmp = ft_strdup(macro->m_pwd);
-		path = ft_strjoin("minishell:~", tmp + len, NULL);
-		path = ft_strjoin(path, "$ ", NULL);
+		path = ft_strjoin3("minishell:~", tmp + len, "$ ");
 		free(home);
 		free(tmp);
 		return (path);
@@ -133,21 +132,18 @@ static char	*upper_than_home(t_macro *macro)
 static char	*create_path(t_macro *macro)
 {
 	char	*path;
-	char	*tmp;
+	char	*up_home;
 	
+	up_home = upper_than_home(macro);
 	if (in_root(macro->m_pwd))
 		path = ft_strdup("minishell:/$ ");
 	else if (in_home(macro))
 		path = ft_strdup("minishell:~$ ");
-	else if (upper_than_home(macro) != NULL)
+	else if (up_home)
 		path = upper_than_home(macro);
 	else
-	{
-		tmp = ft_strjoin("minishell:", macro->m_pwd, NULL);
-		tmp = ft_strjoin(tmp, "$ ", NULL);
-		path = ft_strdup(tmp);
-		free(tmp);
-	}
+		path = ft_strjoin3("minishell:", macro->m_pwd, "$ ");
+	free(up_home);
 	return (path);
 }
 

--- a/src/main_utils.c
+++ b/src/main_utils.c
@@ -6,11 +6,31 @@
 /*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/07 08:50:33 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/08/08 01:38:33 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/28 16:19:20 by dbejar-s         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+char	*ft_strjoin3(const char *s1, const char *s2, const char *s3) 
+{
+    int		total_len;
+	char	*res;
+	
+	if (!s1 || !s2 || !s3)
+        return (NULL);
+	total_len = 0;
+	total_len += ft_strlen(s1);
+	total_len += ft_strlen(s2);
+	total_len += ft_strlen(s3);
+    res = (char *)ft_calloc(sizeof(char), (total_len + 1)); // +1 for the null terminator
+    if (!res)
+        return (NULL);
+    ft_strcpy(res, s1);
+    ft_strcat(res, s2);
+    ft_strcat(res, s3);
+    return (res);
+}
 
 char	**ft_replace_matrix_row(char ***whole, char **minus, int n)
 {


### PR DESCRIPTION
Update minishell.h, free.c, main.c, and main_utils.c files with changes made by dbejar-s.

- Add ft_strjoin3 function to main_utils.c.
- Modify the create_path function in main.c to use ft_strjoin3.
- Remove unused code in free.c.
- Add ft_strjoin3 function declaration to minishell.h.

Problem was using ft_strjoin twice in a row on the same char *