### PR TITLE
fix: handle some fd leaks

### DIFF
--- a/src/free.c
+++ b/src/free.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   free.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/04 13:02:09 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/28 16:19:47 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/28 20:35:09 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -86,5 +86,6 @@ void	free_macro(t_macro *macro)
 	free_ins(macro);
 	free_string(&macro->m_pwd);
 	free_string(&macro->m_home);
+	close_fds(macro->pipe_fd, 0);
 	free(macro);
 }

--- a/src/validation_utils.c
+++ b/src/validation_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   validation_utils.c                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/13 23:25:19 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/28 03:13:46 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/28 21:32:54 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,8 +31,7 @@ int	open_file(t_token *token, t_macro *macro)
 			macro->exit_code = (NO_FILE);
 		else if (errno == EISDIR)
 			macro->exit_code = (NO_FILE);
-		//perror(token->value)-> this message is also correct
-		exit_error(token->value, strerror(errno), macro, macro->exit_code);
+		perror(token->value);
 		return (-1);
 	}
 	return (fd);


### PR DESCRIPTION
This code handles a missing read file descriptor from the pipe_exit and improves other aspects.

After a lot of evaluations, seems that executing just one building make valgrind angry and mark as one fd is open, usually the 0 or 1. But this is not considered a fd leak.

I tested also live the open fds during execution and all is clean, including this single builtin case.