### PR TITLE
Fix/leaks command not found

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/28 16:17:44 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/29 13:30:52 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -95,6 +95,7 @@ typedef struct s_macro
 	char			*m_pwd;
 	char			*m_home;
 	int				exit_code;
+	int				pipe_exit[2];
 }					t_macro;
 
 /* presyntax*/
@@ -148,7 +149,7 @@ char				**build_cmd_args_array(t_token *cmd_args, t_macro *macro);
 char				**prepare_child_execution(t_macro *macro, t_cmd *cmd);
 int					wait_processes(pid_t pid);
 void				catch_parent_exit(int *pipe_exit, int *exit_code);
-void				close_fds(int *pipe_fd, int read_end);
+void				close_fds(t_macro *macro, int read_end);
 
 /* validation */
 void				validation(t_macro *macro, t_cmd *cmd);

--- a/src/execution.c
+++ b/src/execution.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:23:53 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 11:03:45 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/29 13:24:53 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -132,7 +132,7 @@ void	execution(t_macro *macro)
 			catch_parent_exit(pipe_exit, &status);
 		macro->exit_code = status;
 		free(macro->pid);
-    macro->pid = NULL;
+		macro->pid = NULL;
 		close_fds(macro->pipe_fd, read_end);
 	}
 	return ;

--- a/src/execution.c
+++ b/src/execution.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:23:53 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 13:24:53 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/29 13:42:46 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,14 +42,14 @@ int	execute_single_builtin(t_macro *macro)
 	return (macro->exit_code);
 }
 
-static void	execute_child_process(t_macro *macro, int index, int read_end, int pipe_exit[2])
+static void	execute_child_process(t_macro *macro, int index, int read_end)
 {
 	int		i;
 	t_cmd	*cmd;
 	char	**cmd_array;
 	int		status;
 
-	close(pipe_exit[0]);
+	close(macro->pipe_exit[0]);
 	cmd = macro->cmds;
 	i = 0;
 	while (cmd != NULL && i++ < index)
@@ -64,14 +64,14 @@ static void	execute_child_process(t_macro *macro, int index, int read_end, int p
 	status = macro->exit_code;
 	if (index == macro->num_cmds - 1)
 	{
-		close(pipe_exit[0]);
-		write(pipe_exit[1], &status, sizeof(int));
-		close(pipe_exit[1]);
+		close(macro->pipe_exit[0]);
+		write(macro->pipe_exit[1], &status, sizeof(int));
+		close(macro->pipe_exit[1]);
 	}
 	exit(status);
 }
 
-static int	execute_cmds(t_macro *macro, int read_end, int pipe_exit[2])
+static int	execute_cmds(t_macro *macro, int read_end)
 {
 	int	i;
 	int	status;
@@ -84,11 +84,11 @@ static int	execute_cmds(t_macro *macro, int read_end, int pipe_exit[2])
 		macro->pid[i] = fork();
 		if (macro->pid[i] < 0)
 		{
-			close_fds(macro->pipe_fd, read_end);
+			close_fds(macro, read_end);
 			return (error_msg("fork failed", i));
 		}
 		else if (macro->pid[i] == 0)
-			execute_child_process(macro, i, read_end, pipe_exit);
+			execute_child_process(macro, i, read_end);
 		if (read_end > 0)
 			close(read_end);
 		read_end = macro->pipe_fd[0];
@@ -97,7 +97,7 @@ static int	execute_cmds(t_macro *macro, int read_end, int pipe_exit[2])
 	}
 	if (macro->pid != 0)
 	{
-		catch_parent_exit(pipe_exit, &status);
+		catch_parent_exit(macro->pipe_exit, &status);
 		macro->exit_code = status;
 	}
 	return (i);
@@ -107,7 +107,6 @@ void	execution(t_macro *macro)
 {
 	int		read_end;
 	int		num_cmds_executed;
-	int		pipe_exit[2];
 	int		i;
 	int		status;
 
@@ -117,23 +116,23 @@ void	execution(t_macro *macro)
 		execute_single_builtin(macro);
 	else
 	{
-		if (pipe(pipe_exit) == -1)
+		if (pipe(macro->pipe_exit) == -1)
 		{
 			error_msg("pipe failed", 0);
 			return ;
 		}
 		read_end = 0;
 		macro->pid = malloc(sizeof(pid_t) * macro->num_cmds); //TODO: protect
-		num_cmds_executed = execute_cmds(macro, read_end, pipe_exit);
+		num_cmds_executed = execute_cmds(macro, read_end);
 		i = 0;
 		while (i < num_cmds_executed)
 			status = wait_processes(macro->pid[i++]);
 		if (macro->pid != 0) //is this correct and need? you are in the parent
-			catch_parent_exit(pipe_exit, &status);
+			catch_parent_exit(macro->pipe_exit, &status);
 		macro->exit_code = status;
 		free(macro->pid);
 		macro->pid = NULL;
-		close_fds(macro->pipe_fd, read_end);
+		close_fds(macro, read_end);
 	}
 	return ;
 }

--- a/src/execution_utils.c
+++ b/src/execution_utils.c
@@ -3,26 +3,36 @@
 /*                                                        :::      ::::::::   */
 /*   execution_utils.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/09 20:03:14 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/28 03:11:29 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/29 13:35:32 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-void	close_fds(int *pipe_fd, int read_end)
+void	close_fds(t_macro *macro, int read_end)
 {
-	if (pipe_fd[0] != -1)
+	if (macro->pipe_fd[0] != -1)
 	{
-		close(pipe_fd[0]);
-		pipe_fd[0] = -1;
+		close(macro->pipe_fd[0]);
+		macro->pipe_fd[0] = -1;
 	}
-	if (pipe_fd[1] != -1)
+	if (macro->pipe_fd[1] != -1)
 	{
-		close(pipe_fd[1]);
-		pipe_fd[1] = -1;
+		close(macro->pipe_fd[1]);
+		macro->pipe_fd[1] = -1;
+	}
+	if (macro->pipe_exit[0] != -1)
+	{
+		close(macro->pipe_exit[0]);
+		macro->pipe_exit[0] = -1;
+	}
+	if (macro->pipe_exit[1] != -1)
+	{
+		close(macro->pipe_exit[1]);
+		macro->pipe_exit[1] = -1;
 	}
 	if (read_end > 0)
 		close(read_end);

--- a/src/free.c
+++ b/src/free.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/04 13:02:09 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 11:18:28 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/29 13:38:17 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -76,18 +76,17 @@ void	free_ins(t_macro *macro)
 	free_tokens(&macro->tokens);
 	free_cmds(&macro->cmds);
 	free(macro->pid);
-	close_fds(macro->pipe_fd, 0);
+	close_fds(macro, 0);
 	macro->num_cmds = 0;
 }
 
 void	free_macro(t_macro *macro)
 {
+	free_ins(macro);
 	free_array(&macro->env);
 	free_array(&macro->history);
 	free_string(&macro->instruction);
-	free_ins(macro);
 	free_string(&macro->m_pwd);
 	free_string(&macro->m_home);
-	close_fds(macro->pipe_fd, 0);
 	free(macro);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 11:20:41 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/29 13:26:00 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -78,6 +78,8 @@ t_macro	*init_macro(char **envp, char **argv)
 	macro->exit_code = 0;
 	macro->pipe_fd[0] = -1;
 	macro->pipe_fd[1] = -1;
+	macro->pipe_exit[0] = -1;
+	macro->pipe_exit[1] = -1;
 	return (macro);
 }
 

--- a/src/validation.c
+++ b/src/validation.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   validation.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:35:57 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/28 03:30:55 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/29 13:22:05 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,12 +70,13 @@ void	search_executable(t_macro *macro, t_cmd *cmd)
 		exit_error(cmd->cmd_arg->value, "No such file or directory", macro, 127);
 	}
 	full_path = get_executable_path(paths, cmd->cmd_arg->value, macro);
-	free(paths);
+	free_array(&paths);
 	if (!full_path)
 	{
 		ft_putstr_fd(cmd->cmd_arg->value, 2);
 		ft_putstr_fd(": command not found\n", 2);
-		exit(macro->exit_code);
+		free_macro(macro);
+		exit(127);
 	}
 	else
 	{


### PR DESCRIPTION
This update fix all leaks related to exiting early inside a child due to a `command not found`.

To avoid file descriptor leaks, `pipex_exit` is moved to `macro` struct. 