### PR TITLE
feat: improve validation error handling

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   error.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/10 13:00:20 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/28 04:12:07 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/29 15:06:15 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,5 +27,6 @@ void exit_error(char *file, char *msg, t_macro *macro, int exit_code)
 	ft_putstr_fd(msg, 2);
 	ft_putstr_fd("\n", 2);
 	macro->exit_code = exit_code;
+	free_ins(macro);
 	exit(exit_code);
 }

--- a/src/execution.c
+++ b/src/execution.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:23:53 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 13:42:46 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/29 15:14:28 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,8 +32,8 @@ int	execute_single_builtin(t_macro *macro)
 	saved_stdin = dup(STDIN_FILENO);
 	if(validate_redirections(macro->cmds->redir, macro) == -1)
 		return(-1);
-	dup_file_descriptors(macro, macro->cmds, 0);
-	cmd_array = build_cmd_args_array(macro->cmds->cmd_arg, macro); //TODO: protect
+	dup_file_descriptors(macro, macro->cmds, 0); // TODO: protect
+	cmd_array = build_cmd_args_array(macro->cmds->cmd_arg, macro); // TODO: protect
 	macro->exit_code = execute_builtin(macro, cmd_array);
 	dup2(saved_stdout, STDOUT_FILENO);
 	dup2(saved_stdin, STDIN_FILENO);
@@ -55,14 +55,14 @@ static void	execute_child_process(t_macro *macro, int index, int read_end)
 	while (cmd != NULL && i++ < index)
 		cmd = cmd->next;
 	validation(macro, cmd);
-	dup_file_descriptors(macro, cmd, read_end);
+	dup_file_descriptors(macro, cmd, read_end); // TODO: protect
 	cmd_array = build_cmd_args_array(cmd->cmd_arg, macro);
 	if (cmd->type == BUILTIN)
 		macro->exit_code = execute_builtin(macro, cmd_array);
 	else
 		execve(cmd_array[0], cmd_array, macro->env);
 	status = macro->exit_code;
-	if (index == macro->num_cmds - 1)
+	if (index == macro->num_cmds - 1)  // TODO: split into function
 	{
 		close(macro->pipe_exit[0]);
 		write(macro->pipe_exit[1], &status, sizeof(int));

--- a/src/validation.c
+++ b/src/validation.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:35:57 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 13:22:05 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/29 15:10:56 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,17 +65,14 @@ void	search_executable(t_macro *macro, t_cmd *cmd)
 	full_path = NULL;
 	paths = parse_paths(macro->env);
 	if (!paths)
-	{
-		macro->exit_code = 127;
 		exit_error(cmd->cmd_arg->value, "No such file or directory", macro, 127);
-	}
 	full_path = get_executable_path(paths, cmd->cmd_arg->value, macro);
 	free_array(&paths);
 	if (!full_path)
 	{
 		ft_putstr_fd(cmd->cmd_arg->value, 2);
 		ft_putstr_fd(": command not found\n", 2);
-		free_macro(macro);
+		free_ins(macro);
 		exit(127);
 	}
 	else
@@ -85,13 +82,15 @@ void	search_executable(t_macro *macro, t_cmd *cmd)
 	}
 }
 
-void	validation(t_macro *macro, t_cmd *cmd)
+void validation(t_macro *macro, t_cmd *cmd)
 {
-	if (cmd && cmd->type == CMD)
+	
+	if (ft_strchr("./", cmd->cmd_arg->value[0]) == NULL)
+		search_executable(macro, cmd);
+	validate_access(cmd->cmd_arg->value, macro);
+	if(validate_redirections(cmd->redir, macro) == -1)
 	{
-		if (ft_strchr("./", cmd->cmd_arg->value[0]) == NULL)
-			search_executable(macro, cmd);
-		validate_access(cmd->cmd_arg->value, macro);
+		free_ins(macro);
+		exit(1);
 	}
-	validate_redirections(cmd->redir, macro);
 }


### PR DESCRIPTION
This update fixes the double message error issue.

How we manage errors in between function executions has been improved and we now return or exit accordingly depending on where we are and what we are (CMD or BUILTIN).

`exit_error` now also runs `free_ins` to clean everything before leaving the child.