### PR TITLE
feat: Add error handling for too many arguments in cd command

### DIFF
--- a/src/buin_cd.c
+++ b/src/buin_cd.c
@@ -6,11 +6,23 @@
 /*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/27 09:04:29 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/08/29 13:24:43 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/29 23:51:12 by dbejar-s         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+static int	count_args(char **args)
+{
+	int	i;
+
+	i = 0;
+	while (args[i])
+		i++;
+	if (i > 2)
+		ft_putendl_fd("minishell: cd: too many arguments", STDERR_FILENO);
+	return (i);
+}
 
 int	ft_cd2(char **args, t_macro *macro)
 {
@@ -20,12 +32,12 @@ int	ft_cd2(char **args, t_macro *macro)
 	int		argc;
 
 	home = get_home_directory(macro);
-	argc = 0;
-	while (args[argc])
-		argc++;
+	argc = count_args(args);
 	if (argc > 2)
+		return (1);
+	if (home == NULL && (!args[1] || args[1][0] == '\0'))
 	{
-		ft_putendl_fd("minishell: cd: too many arguments", STDERR_FILENO);
+		ft_putendl_fd("minishell: cd: HOME not set", STDERR_FILENO);
 		return (1);
 	}
 	path = parse_arguments(args, macro, home);

--- a/src/buin_cd_utils.c
+++ b/src/buin_cd_utils.c
@@ -6,7 +6,7 @@
 /*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/29 13:15:25 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/08/29 13:34:47 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/29 23:54:48 by dbejar-s         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,15 +32,17 @@ char	*parse_arguments(char **args, t_macro *macro, char *home)
 
 	if (!args[1] || args[1][0] == '\0')
 		path = ft_strdup(home);
-	else if (ft_strncmp(args[1], "~", 1) == 0)
+	else if (ft_strncmp(args[1], "~", 1) == 0 && args[1][1] == '\0')
 		path = ft_strdup(macro->m_home);
+	else if (ft_strncmp(args[1], "~/", 2) == 0)
+		path = ft_strjoin(macro->m_home, args[1] + 1, NULL);
 	else if (ft_strncmp(args[1], "-", 1) == 0)
 	{
 		path = grab_env("OLDPWD", macro->env, 6);
 		if (!path)
 		{
 			ft_putendl_fd("minishell: cd: OLDPWD not set", STDERR_FILENO);
-			free(home);
+			free_string(&home);
 			return (NULL);
 		}
 	}


### PR DESCRIPTION
Fix a bug when HOME is unset and cd $HOME
Added feature cd ~/algo expands ~ to $HOME (even if HOME is unset)