### PR TITLE
fix: clean leaks related to lexeme handling

### DIFF
--- a/src/expand.c
+++ b/src/expand.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   expand.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/21 18:52:58 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/30 01:06:35 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/30 14:25:25 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,13 +67,14 @@ char	*build_expanded_instruction(char *clean, char *ins, t_macro *macro)
 		else
 			clean[j++] = ins[i++];
 	}
-	free(exit_str);
+	free_string(&exit_str);
 	return (clean);
 }
 
 size_t	expanded_envir_len(char *ins, t_macro *macro)
 {
 	size_t	envir_len;
+	char 	*exit_code;
 	int		i;
 	char	*envir_name;
 	char	*envir_value;
@@ -95,7 +96,9 @@ size_t	expanded_envir_len(char *ins, t_macro *macro)
 			if (ins[i] == '?')
 			{
 				i++;
-				envir_len += ft_strlen(ft_itoa(macro->exit_code));
+				exit_code = ft_itoa(macro->exit_code);
+				envir_len += ft_strlen(exit_code);
+				free_string(&exit_code);
 			}
 			else
 			{

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/03 21:24:44 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 16:17:14 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/30 14:35:39 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,18 +67,20 @@ t_token	*identify_tokens(t_list *lexemes)
 {
 	t_token	*tokens;
 	t_token	*token;
+	t_list 	*tmp;
 
 	tokens = NULL;
-	while (lexemes)
+	tmp = lexemes;
+	while (tmp)
 	{
-		token = identify_redirection_tokens(lexemes->content);
+		token = identify_redirection_tokens(tmp->content);
 		if (!token)
 		{
 			free_tokens(&tokens);
 			return (NULL);
 		}
 		token_add_back(&tokens, token);
-		lexemes = lexemes->next;
+		tmp = tmp->next;
 	}
 	ft_lstclear(&lexemes, ft_del);
 	lexemes = NULL;

--- a/src/tokenizer_expand.c
+++ b/src/tokenizer_expand.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/22 17:45:23 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 16:18:42 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/30 14:20:22 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -90,7 +90,10 @@ t_token	*expand_arg_tokens(t_macro *macro)
 			if (!expanded || *expanded == '\0')
 				return (NULL);
 			if (ft_strchr("\"", tokens->value[0]))
+			{
+				free_string(&tokens->value);
 				tokens->value = expanded;
+			}
 			else
 			{
 				retokens = retokenize(tokens, macro);
@@ -98,7 +101,6 @@ t_token	*expand_arg_tokens(t_macro *macro)
 					return (NULL);
 				plug_retokens(tokens, retokens, macro);
 			}
-			free(expanded);
 		}
 		tokens = tokens->next;
 	}


### PR DESCRIPTION
This update fix some leaks related to `expand` char and incorrect reference of `ft_lstclear` cleaning the last node of lexemes instead of from head down.