### PR TITLE
Fix/leaks with only redirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+         #
+#    By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/08/01 15:11:43 by pmarkaid          #+#    #+#              #
-#    Updated: 2024/08/28 17:58:15 by dbejar-s         ###   ########.fr        #
+#    Updated: 2024/08/29 11:47:48 by pmarkaid         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -60,8 +60,8 @@ TEST_OBJS = $(TEST_SRCS:.c=.o)
 TEST_NAME = tests_runner
 
 CC = cc 
-CFLAGS = -Wall -Werror -Wextra -fsanitize=address -g
-DEBUG_FLAGS = -g
+CFLAGS = -Wall -Werror -Wextra -g
+DEBUG_FLAGS = -Wall -Werror -Wextra -fsanitize=address -g
 
 # External Libraries
 LIBS = -lreadline

--- a/lib/libft/get_next_line.c
+++ b/lib/libft/get_next_line.c
@@ -6,11 +6,18 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/10 10:54:48 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/01/17 15:51:21 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/31 11:04:16 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
+
+static char	*ft_free_str(char **str)
+{
+	free(*str);
+	*str = NULL;
+	return (NULL);
+}
 
 char	*load_buffer(int fd, char *remainder)
 {
@@ -25,7 +32,7 @@ char	*load_buffer(int fd, char *remainder)
 		remainder_len = ft_strlenc(remainder, '\0');
 		new_buffer = malloc(sizeof(char) * (remainder_len + bytes_read + 1));
 		if (!new_buffer)
-			return (ft_free(&remainder));
+			return (ft_free_str(&remainder));
 		ft_memmove(new_buffer, remainder, remainder_len);
 		ft_memmove(new_buffer + remainder_len, buffer, bytes_read);
 		new_buffer[remainder_len + bytes_read] = '\0';
@@ -36,7 +43,7 @@ char	*load_buffer(int fd, char *remainder)
 		bytes_read = read(fd, buffer, BUFFER_SIZE);
 	}
 	if (bytes_read == -1)
-		return (ft_free(&remainder));
+		return (ft_free_str(&remainder));
 	return (remainder);
 }
 
@@ -47,7 +54,7 @@ char	*parse_line(char *remainder)
 	char	*line;
 
 	if (!remainder)
-		return (ft_free(&remainder));
+		return (ft_free_str(&remainder));
 	line_len = ft_strlenc(remainder, '\n');
 	newline = ft_strchr(remainder, '\n');
 	if (newline)
@@ -68,11 +75,11 @@ char	*update_remainder(char *remainder)
 
 	newline = ft_strchr(remainder, '\n');
 	if (!newline)
-		return (ft_free(&remainder));
+		return (ft_free_str(&remainder));
 	remainder_len = ft_strlenc(newline, '\0');
 	new_remainder = malloc(sizeof(char) * (remainder_len + 1));
 	if (!new_remainder)
-		return (ft_free(&remainder));
+		return (ft_free_str(&remainder));
 	ft_memmove(new_remainder, newline + 1, remainder_len);
 	free(remainder);
 	return (new_remainder);
@@ -87,10 +94,10 @@ char	*get_next_line(int fd)
 		return (NULL);
 	remainder[fd] = load_buffer(fd, remainder[fd]);
 	if (!remainder[fd] || *remainder[fd] == '\0')
-		return (ft_free(&remainder[fd]));
+		return (ft_free_str(&remainder[fd]));
 	line = parse_line(remainder[fd]);
 	if (!line)
-		return (ft_free(&remainder[fd]));
+		return (ft_free_str(&remainder[fd]));
 	remainder[fd] = update_remainder(remainder[fd]);
 	return (line);
 }

--- a/src/execution.c
+++ b/src/execution.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:23:53 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/30 14:47:21 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/30 15:40:38 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -160,8 +160,7 @@ void	execution(t_macro *macro)
 		if (macro->pid != 0) //is this correct and need? you are in the parent
 			read_pipe_exit(macro->pipe_exit, &status);
 		macro->exit_code = status;
-		free(macro->pid);
-		macro->pid = NULL;
+		ft_free((void **)&macro->pid);
 		close_fds(macro, read_end);
 	}
 	return ;

--- a/src/execution.c
+++ b/src/execution.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   execution.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:23:53 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 00:00:56 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/29 12:08:35 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@ int	execute_builtin(t_macro *macro, char **cmd_array)
 
 	builtin = remove_path(cmd_array[0]);
 	macro->exit_code = select_and_run_builtin(builtin, cmd_array, macro);
-	//free_array(&cmd_array);
+	free_array(&cmd_array);
 	return (macro->exit_code);
 }
 
@@ -35,7 +35,6 @@ int	execute_single_builtin(t_macro *macro)
 	dup_file_descriptors(macro, macro->cmds, 0);
 	cmd_array = build_cmd_args_array(macro->cmds->cmd_arg, macro); //TODO: protect
 	macro->exit_code = execute_builtin(macro, cmd_array);
-	free_array(&cmd_array);
 	dup2(saved_stdout, STDOUT_FILENO);
 	dup2(saved_stdin, STDIN_FILENO);
 	close(saved_stdout);

--- a/src/expand.c
+++ b/src/expand.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   expand.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/21 18:52:58 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/30 01:06:35 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/30 14:25:25 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,13 +67,14 @@ char	*build_expanded_instruction(char *clean, char *ins, t_macro *macro)
 		else
 			clean[j++] = ins[i++];
 	}
-	free(exit_str);
+	free_string(&exit_str);
 	return (clean);
 }
 
 size_t	expanded_envir_len(char *ins, t_macro *macro)
 {
 	size_t	envir_len;
+	char 	*exit_code;
 	int		i;
 	char	*envir_name;
 	char	*envir_value;
@@ -95,7 +96,9 @@ size_t	expanded_envir_len(char *ins, t_macro *macro)
 			if (ins[i] == '?')
 			{
 				i++;
-				envir_len += ft_strlen(ft_itoa(macro->exit_code));
+				exit_code = ft_itoa(macro->exit_code);
+				envir_len += ft_strlen(exit_code);
+				free_string(&exit_code);
 			}
 			else
 			{

--- a/src/free.c
+++ b/src/free.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/04 13:02:09 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 14:37:56 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/30 15:09:12 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,7 +59,7 @@ void	free_macro(t_macro *macro)
 	free_ins(macro);
 	free_array(&macro->env);
 	free_array(&macro->history);
-	free_string(&macro->instruction);
+	//free_string(&macro->instruction);
 	free_string(&macro->m_pwd);
 	free_string(&macro->m_home);
 	free(macro);

--- a/src/free.c
+++ b/src/free.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/04 13:02:09 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 11:53:49 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/29 12:05:02 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -76,7 +76,7 @@ void	free_ins(t_macro *macro)
 	free_tokens(&macro->tokens);
 	free_cmds(&macro->cmds);
 	free(macro->pid);
-	//close_fds(macro->pipe_fd, 0);
+	close_fds(macro->pipe_fd, 0);
 	macro->num_cmds = 0;
 }
 
@@ -84,7 +84,7 @@ void	free_macro(t_macro *macro)
 {
 	free_array(&macro->env);
 	free_array(&macro->history);
-	//free_string(&macro->instruction);
+	free_string(&macro->instruction);
 	free_ins(macro);
 	free_string(&macro->m_pwd);
 	free_string(&macro->m_home);

--- a/src/free.c
+++ b/src/free.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   free.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/04 13:02:09 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 00:02:03 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/29 11:53:49 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,7 +84,7 @@ void	free_macro(t_macro *macro)
 {
 	free_array(&macro->env);
 	free_array(&macro->history);
-	free_string(&macro->instruction);
+	//free_string(&macro->instruction);
 	free_ins(macro);
 	free_string(&macro->m_pwd);
 	free_string(&macro->m_home);

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/27 13:00:44 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/27 22:21:52 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,12 +77,25 @@ int	main(int argc, char **argv, char **envp)
 	signal(SIGQUIT, SIG_IGN);
 	while (1)
 	{
-		path = ft_strjoin("minishell>", " ", NULL);
-		line = readline(path);
+		if (isatty(fileno(stdin)))
+        {
+			path = ft_strjoin("minishell>", " ", NULL);
+			line = readline(path);
+		}
+		else
+		{
+			line = get_next_line(fileno(stdin));
+            if (line)
+            {
+                char *trimmed_line = ft_strtrim(line, "\n");
+                free(line);
+                line = trimmed_line;
+            }
+		}
 		if (line == NULL || *line == EOF)
 		{
 			g_exit = 0;
-			printf("exit\n");
+			//printf("exit\n");
 			break ;
 		}
 		if (ft_str_empty(line))

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/30 14:46:23 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/30 15:18:48 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,80 +14,104 @@
 
 int			g_exit;
 
-static char	*read_line(t_macro *macro)
-{
-	char	*line;
-	char	*path;
-
-	if (g_exit == 130)
-		line = readline("");
-	else
-	{
-		path = create_path(macro);
-		line = readline(path);
-		free(path);
-	}
-	return (line);
-}
-
-static int	evaluate_line(char *line, t_macro *macro)
-{
-	if (line == NULL || *line == EOF)
-	{
-		printf("exit\n");
-		return (-1);
-	}
-	if (ft_str_empty(line))
-		return (1);
-	if (line[0] != '\0')
-		add_history(line);
-	if (syntax_error_check(macro, line))
-		return (1);
-	if (g_exit > 0)
-	{
-		macro->exit_code = g_exit;
-		g_exit = 0;
-	}
-	macro->instruction = line;
-	return (0);
-}
-
-static void	execute_commands(t_macro *macro)
-{
-	if(tokenizer(macro) == -1)
-		return;
-	if(parsing(macro) == -1)
-		return;
-	execution(macro);
-	free_ins(macro);
-}
-
 int main(int argc, char **argv, char **envp)
 {
-	t_macro	*macro;
-	char	*line;
-	int		status;
+    t_macro *macro;
+    char *line;
+    char *path;
 
-	(void)argc;
-	g_exit = 0;
-	macro = init_macro(envp, argv);
-	signal(SIGINT, ft_signal_handler);
-	signal(SIGQUIT, SIG_IGN);
-	while (1)
-	{
-		line = read_line(macro);
-		status = evaluate_line(line, macro);
-		if (status == -1)
-			break ;
-		else if (status == 1)
-		{
-			free_string(&line);
-			continue ;
-		}
-		execute_commands(macro);
-	}
-	free_macro(macro);
-	exit(0);
+    g_exit = 0;
+    macro = init_macro(envp, argv);
+    signal(SIGINT, ft_signal_handler);
+    signal(SIGQUIT, SIG_IGN);
+
+    if (argc == 3 && strcmp(argv[1], "-c") == 0)
+    {
+        // Handle command passed via -c option
+        line = argv[2];
+
+        if (line && !ft_str_empty(line))
+        {
+            macro->instruction = line;
+            tokenizer(macro);
+            parsing(macro);
+            if (macro->cmds)
+            {
+                execution(macro);
+                free_ins(macro);
+            }
+        }
+
+        free_macro(macro);
+        exit(0);
+    }
+
+    while (1)
+    {
+        if (isatty(fileno(stdin)))
+        {
+            if (g_exit == 130)
+                line = readline("");
+            else
+            { 
+                path = create_path(macro);
+                line = readline(path);
+                free(path);
+            }
+        }
+        else
+        {
+            line = get_next_line(fileno(stdin));
+            if (line)
+            {
+                char *trimmed_line = ft_strtrim(line, "\n");
+                free(line);
+                line = trimmed_line;
+            }
+        }
+
+        if (line == NULL || *line == EOF)
+        {
+            g_exit = 0;
+            break;
+        }
+
+        if (ft_str_empty(line))
+        {
+            free(line);
+            continue;
+        }
+
+        if (line[0] != '\0')
+            add_history(line);
+
+        if (syntax_error_check(macro, line))
+        {
+            macro->exit_code = 2;
+            free(line);
+            continue;
+        }
+
+        if (g_exit > 0)
+        {
+            macro->exit_code = g_exit;
+            g_exit = 0;
+        }
+
+        macro->instruction = line;
+        tokenizer(macro);
+        parsing(macro);
+        if (macro->cmds == NULL)
+        {
+            free(line);
+            continue;
+        }
+
+        execution(macro);
+        free_ins(macro);
+    }
+
+    free_macro(macro);
+    exit(0);
 }
-
 

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 11:51:59 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/29 12:12:06 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,7 +64,7 @@ t_macro	*init_macro(char **envp, char **argv)
 		ft_putstr_fd("Error: Malloc failed creating macro structure\n", 2);
 		exit(1);
 	}
-	ft_bzero(macro, sizeof(t_macro));
+	ft_bzero(macro, sizeof(t_macro));macro->pipe_fd[0] = -1;
 	macro->envp = envp;
 	macro->env = copy_env(envp);
 	macro->history = NULL;
@@ -76,6 +76,8 @@ t_macro	*init_macro(char **envp, char **argv)
 	macro->m_pwd = char_pwd();
 	macro->m_home = grab_home(macro);
 	macro->exit_code = 0;
+	macro->pipe_fd[0] = -1;
+	macro->pipe_fd[1] = -1;
 	return (macro);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/30 15:18:48 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/31 11:31:54 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,104 +14,79 @@
 
 int			g_exit;
 
-int main(int argc, char **argv, char **envp)
+static char	*read_line(t_macro *macro)
 {
-    t_macro *macro;
-    char *line;
-    char *path;
+	char	*line;
+	char	*path;
 
-    g_exit = 0;
-    macro = init_macro(envp, argv);
-    signal(SIGINT, ft_signal_handler);
-    signal(SIGQUIT, SIG_IGN);
+	if (g_exit == 130)
+		line = readline("");
+	else
+	{
+		path = create_path(macro);
+		line = readline(path);
+		free(path);
+	}
+	return (line);
+}
 
-    if (argc == 3 && strcmp(argv[1], "-c") == 0)
-    {
-        // Handle command passed via -c option
-        line = argv[2];
+static int	evaluate_line(char *line, t_macro *macro)
+{
+	if (line == NULL || *line == EOF)
+	{
+		printf("exit\n");
+		return (-1);
+	}
+	if (ft_str_empty(line))
+		return (1);
+	if (line[0] != '\0')
+		add_history(line);
+	if (syntax_error_check(macro, line))
+		return (1);
+	if (g_exit > 0)
+	{
+		macro->exit_code = g_exit;
+		g_exit = 0;
+	}
+	macro->instruction = line;
+	return (0);
+}
 
-        if (line && !ft_str_empty(line))
-        {
-            macro->instruction = line;
-            tokenizer(macro);
-            parsing(macro);
-            if (macro->cmds)
-            {
-                execution(macro);
-                free_ins(macro);
-            }
-        }
+static void	execute_commands(t_macro *macro)
+{
+	if(tokenizer(macro) == -1)
+		return;
+	if(parsing(macro) == -1)
+		return;
+	execution(macro);
+	free_ins(macro);
+}
 
-        free_macro(macro);
-        exit(0);
-    }
+int	main(int argc, char **argv, char **envp)
+{
+	t_macro	*macro;
+	char	*line;
+	int		status;
 
-    while (1)
-    {
-        if (isatty(fileno(stdin)))
-        {
-            if (g_exit == 130)
-                line = readline("");
-            else
-            { 
-                path = create_path(macro);
-                line = readline(path);
-                free(path);
-            }
-        }
-        else
-        {
-            line = get_next_line(fileno(stdin));
-            if (line)
-            {
-                char *trimmed_line = ft_strtrim(line, "\n");
-                free(line);
-                line = trimmed_line;
-            }
-        }
-
-        if (line == NULL || *line == EOF)
-        {
-            g_exit = 0;
-            break;
-        }
-
-        if (ft_str_empty(line))
-        {
-            free(line);
-            continue;
-        }
-
-        if (line[0] != '\0')
-            add_history(line);
-
-        if (syntax_error_check(macro, line))
-        {
-            macro->exit_code = 2;
-            free(line);
-            continue;
-        }
-
-        if (g_exit > 0)
-        {
-            macro->exit_code = g_exit;
-            g_exit = 0;
-        }
-
-        macro->instruction = line;
-        tokenizer(macro);
-        parsing(macro);
-        if (macro->cmds == NULL)
-        {
-            free(line);
-            continue;
-        }
-
-        execution(macro);
-        free_ins(macro);
-    }
-
-    free_macro(macro);
-    exit(0);
+	(void)argc;
+	g_exit = 0;
+	macro = init_macro(envp, argv);
+	signal(SIGINT, ft_signal_handler);
+	signal(SIGQUIT, SIG_IGN);
+	while (1)
+	{
+		line = read_line(macro);
+		status = evaluate_line(line, macro);
+		if (status == -1)
+			break ;
+		else if (status == 1)
+		{
+			free_string(&line);
+			continue ;
+		}
+		execute_commands(macro);
+	}
+	free_macro(macro);
+	exit(0);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 11:35:32 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/29 11:51:59 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -147,69 +147,106 @@ static char	*create_path(t_macro *macro)
 	return (path);
 }
 
-int	main(int argc, char **argv, char **envp)
+int main(int argc, char **argv, char **envp)
 {
-	t_macro	*macro;
-	char	*line;
-	char	*path;
+    t_macro *macro;
+    char *line;
+    char *path;
 
-	g_exit = 0;
-	macro = init_macro(envp, argv);
-	(void)argc;
-	signal(SIGINT, ft_signal_handler);
-	signal(SIGQUIT, SIG_IGN);
-	while (1)
-	{
-		if (isatty(fileno(stdin)))
+    g_exit = 0;
+    macro = init_macro(envp, argv);
+    signal(SIGINT, ft_signal_handler);
+    signal(SIGQUIT, SIG_IGN);
+
+    if (argc == 3 && strcmp(argv[1], "-c") == 0)
+    {
+        // Handle command passed via -c option
+        line = argv[2];
+
+        if (line && !ft_str_empty(line))
         {
-			path = ft_strjoin("minishell>", " ", NULL);
-			line = readline(path);
-		}
-		else
-		{
-			line = get_next_line(fileno(stdin));
+            macro->instruction = line;
+            tokenizer(macro);
+            macro->cmds = parsing(macro);
+            if (macro->cmds)
+            {
+                execution(macro);
+                free_ins(macro);
+            }
+        }
+
+        free_macro(macro);
+        exit(0);
+    }
+
+    while (1)
+    {
+        if (isatty(fileno(stdin)))
+        {
+            if (g_exit == 130)
+                line = readline("");
+            else
+            { 
+                path = create_path(macro);
+                line = readline(path);
+                free(path);
+            }
+        }
+        else
+        {
+            line = get_next_line(fileno(stdin));
             if (line)
             {
                 char *trimmed_line = ft_strtrim(line, "\n");
                 free(line);
                 line = trimmed_line;
             }
-		}
-		if (line == NULL || *line == EOF)
-		{
-			g_exit = 0;
-			//printf("exit\n");
-			break ;
-		}
-		if (ft_str_empty(line))
-		{
-			free(line);
-			continue ;
-		}
-		if (line[0] != '\0')
-			add_history(line);
-		if (syntax_error_check(line))
-		{
-			macro->exit_code = 2;
-			free(line);
-			continue ;
-		}
-		if (g_exit > 0)
-		{
-			macro->exit_code = g_exit;
-			g_exit = 0;
-		}
-		macro->instruction = line;
-		tokenizer(macro);
-		macro->cmds = parsing(macro);
-		if (macro->cmds == NULL)
-		{
-			free(line);
-			continue ;
-		}
-		execution(macro);
-		free_ins(macro);
-	}
-	free_macro(macro);
-	exit(0);
+        }
+
+        if (line == NULL || *line == EOF)
+        {
+            g_exit = 0;
+            break;
+        }
+
+        if (ft_str_empty(line))
+        {
+            free(line);
+            continue;
+        }
+
+        if (line[0] != '\0')
+            add_history(line);
+
+        if (syntax_error_check(line))
+        {
+            macro->exit_code = 2;
+            free(line);
+            continue;
+        }
+
+        if (g_exit > 0)
+        {
+            macro->exit_code = g_exit;
+            g_exit = 0;
+        }
+
+        macro->instruction = line;
+        tokenizer(macro);
+        macro->cmds = parsing(macro);
+
+        if (macro->cmds == NULL)
+        {
+            free(line);
+            continue;
+        }
+
+        execution(macro);
+        free_ins(macro);
+    }
+
+    free_macro(macro);
+    exit(0);
 }
+
+

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/03 21:24:44 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 16:17:14 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/30 14:35:39 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,18 +67,20 @@ t_token	*identify_tokens(t_list *lexemes)
 {
 	t_token	*tokens;
 	t_token	*token;
+	t_list 	*tmp;
 
 	tokens = NULL;
-	while (lexemes)
+	tmp = lexemes;
+	while (tmp)
 	{
-		token = identify_redirection_tokens(lexemes->content);
+		token = identify_redirection_tokens(tmp->content);
 		if (!token)
 		{
 			free_tokens(&tokens);
 			return (NULL);
 		}
 		token_add_back(&tokens, token);
-		lexemes = lexemes->next;
+		tmp = tmp->next;
 	}
 	ft_lstclear(&lexemes, ft_del);
 	lexemes = NULL;

--- a/src/tokenizer_expand.c
+++ b/src/tokenizer_expand.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/22 17:45:23 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 16:18:42 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/30 14:20:22 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -90,7 +90,10 @@ t_token	*expand_arg_tokens(t_macro *macro)
 			if (!expanded || *expanded == '\0')
 				return (NULL);
 			if (ft_strchr("\"", tokens->value[0]))
+			{
+				free_string(&tokens->value);
 				tokens->value = expanded;
+			}
 			else
 			{
 				retokens = retokenize(tokens, macro);
@@ -98,7 +101,6 @@ t_token	*expand_arg_tokens(t_macro *macro)
 					return (NULL);
 				plug_retokens(tokens, retokens, macro);
 			}
-			free(expanded);
 		}
 		tokens = tokens->next;
 	}

--- a/src/validation.c
+++ b/src/validation.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   validation.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:35:57 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/30 00:03:12 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/30 15:39:24 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,9 +84,12 @@ void	search_executable(t_macro *macro, t_cmd *cmd)
 
 void	validation(t_macro *macro, t_cmd *cmd)
 {
-	if (ft_strchr("./", cmd->cmd_arg->value[0]) == NULL)
-		search_executable(macro, cmd);
-	validate_access(cmd->cmd_arg->value, macro);
+	if (cmd->cmd_arg)
+	{
+		if(ft_strchr("./", cmd->cmd_arg->value[0]) == NULL)
+			search_executable(macro, cmd);
+		validate_access(cmd->cmd_arg->value, macro);
+	}
 	if (validate_redirections(cmd->redir, macro) == -1)
 	{
 		free_ins(macro);


### PR DESCRIPTION
Fix leaks when the execution only redirection tokens. Examples like

* `<infile`
* `<missing`

There are still more leaks with these instructions, but are related to environmental variable handling.