### PR TITLE
Fix/refactor retokens

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/31 15:20:51 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/31 15:52:05 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -215,7 +215,7 @@ int					ft_echo2(char **args);
 int					ft_cd2(char **args, t_macro *macro);
 char				*ft_strjoin3(const char *s1, const char *s2,
 						const char *s3);
-void				free_2_strings(char **str1, char **str2);
+char				*free_2_strings(char **str1, char **str2);
 char				*get_home_directory(t_macro *macro);
 char				*parse_arguments(char **args, t_macro *macro, char *home);
 int					change_directory(char *path, char *home);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/31 14:35:51 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/31 15:20:51 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -122,7 +122,6 @@ char				*clean_quotes(char *str);
 t_token				*init_token(void);
 void				token_add_back(t_token **tokens, t_token *new);
 t_token				*last_token(t_token *token);
-void				free_tokens(t_token **tokens);
 void				print_tokens(t_token *tokens);
 t_cmd				*init_cmd(void);
 void				cmd_add_back(t_cmd **cmds, t_cmd *new);
@@ -181,11 +180,11 @@ bool				is_in_quote(char *str, int index);
 
 /* free */
 char				*free_string(char **str);
-void				free_array(char ***array);
-void				free_tokens(t_token **tokens);
-void				free_ins(t_macro *macro);
-void				free_macro(t_macro *macro);
-void				free_cmds(t_cmd **cmds);
+char				*free_array(char ***array);
+t_token				*free_tokens(t_token **tokens);
+t_macro				*free_ins(t_macro *macro);
+t_macro				*free_macro(t_macro *macro);
+t_cmd				*free_cmds(t_cmd **cmds);
 
 /* others */
 void				ft_signal_handler(int signum);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 23:38:40 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/31 14:35:51 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -180,7 +180,7 @@ bool				envir_must_be_expanded(char *instruction, int index);
 bool				is_in_quote(char *str, int index);
 
 /* free */
-void				free_string(char **str);
+char				*free_string(char **str);
 void				free_array(char ***array);
 void				free_tokens(t_token **tokens);
 void				free_ins(t_macro *macro);

--- a/src/expand.c
+++ b/src/expand.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/21 18:52:58 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/31 14:36:33 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/31 15:27:28 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -138,12 +138,10 @@ char	*get_expanded_instruction(char *ins, t_macro *macro)
 			return(free_string(&clean));
 		build_expanded_instruction(temp, clean, macro);
 		if (ft_strcmp(temp, clean) == 0)
-		{
-			free_string(&temp);
 			break;
-		}
-		free(clean);
+		free_string(&clean);
 		clean = temp;
 	}
+	free_string(&temp);
 	return (clean);
 }

--- a/src/expand.c
+++ b/src/expand.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/21 18:52:58 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/30 14:25:25 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/31 14:36:33 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -122,15 +122,28 @@ size_t	expanded_envir_len(char *ins, t_macro *macro)
 char	*get_expanded_instruction(char *ins, t_macro *macro)
 {
 	char	*clean;
+	char	*temp;
 	size_t	envir_len;
 	size_t	total_len;
 
-	envir_len = expanded_envir_len(ins, macro);
-	total_len = envir_len + ft_strlen(ins);
-	clean = ft_calloc(1, sizeof(char) * total_len + 1);
+	clean = ft_strdup(ins);
 	if (!clean)
 		return (NULL);
-	clean = build_expanded_instruction(clean, ins, macro);
-	clean[total_len] = '\0';
+	while (1)
+	{
+		envir_len = expanded_envir_len(clean, macro);
+		total_len = envir_len + ft_strlen(clean);
+		temp = ft_calloc(1, sizeof(char) * total_len + 1);
+		if (!temp)
+			return(free_string(&clean));
+		build_expanded_instruction(temp, clean, macro);
+		if (ft_strcmp(temp, clean) == 0)
+		{
+			free_string(&temp);
+			break;
+		}
+		free(clean);
+		clean = temp;
+	}
 	return (clean);
 }

--- a/src/free.c
+++ b/src/free.c
@@ -6,13 +6,13 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/04 13:02:09 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/30 15:09:12 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/31 15:13:07 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-void	free_tokens(t_token **tokens)
+char	*free_tokens(t_token **tokens)
 {
 	t_token	*tmp;
 
@@ -24,15 +24,16 @@ void	free_tokens(t_token **tokens)
 		free(tmp);
 	}
 	*tokens = NULL;
+	return(NULL);
 }
 
-void	free_cmds(t_cmd **cmds)
+char	*free_cmds(t_cmd **cmds)
 {
 	t_cmd	*tmp;
 	t_cmd	*next;
 
 	if (cmds == NULL || *cmds == NULL)
-		return ;
+		return(NULL);
 	tmp = *cmds;
 	while (tmp != NULL)
 	{
@@ -43,24 +44,27 @@ void	free_cmds(t_cmd **cmds)
 		tmp = next;
 	}
 	*cmds = NULL;
+	return(NULL);
 }
 
-void	free_ins(t_macro *macro)
+char	*free_ins(t_macro *macro)
 {
 	free_tokens(&macro->tokens);
 	free_cmds(&macro->cmds);
 	free(macro->pid);
 	close_fds(macro, 0);
 	macro->num_cmds = 0;
+	return(NULL);
 }
 
-void	free_macro(t_macro *macro)
+char	*free_macro(t_macro *macro)
 {
 	free_ins(macro);
 	free_array(&macro->env);
 	free_array(&macro->history);
-	//free_string(&macro->instruction);
+	free_string(&macro->instruction);
 	free_string(&macro->m_pwd);
 	free_string(&macro->m_home);
 	free(macro);
+	return(NULL);
 }

--- a/src/free.c
+++ b/src/free.c
@@ -6,13 +6,13 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/04 13:02:09 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/31 15:13:07 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/31 15:20:14 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-char	*free_tokens(t_token **tokens)
+t_token	*free_tokens(t_token **tokens)
 {
 	t_token	*tmp;
 
@@ -27,7 +27,7 @@ char	*free_tokens(t_token **tokens)
 	return(NULL);
 }
 
-char	*free_cmds(t_cmd **cmds)
+t_cmd	*free_cmds(t_cmd **cmds)
 {
 	t_cmd	*tmp;
 	t_cmd	*next;
@@ -47,7 +47,7 @@ char	*free_cmds(t_cmd **cmds)
 	return(NULL);
 }
 
-char	*free_ins(t_macro *macro)
+t_macro	*free_ins(t_macro *macro)
 {
 	free_tokens(&macro->tokens);
 	free_cmds(&macro->cmds);
@@ -57,7 +57,7 @@ char	*free_ins(t_macro *macro)
 	return(NULL);
 }
 
-char	*free_macro(t_macro *macro)
+t_macro	*free_macro(t_macro *macro)
 {
 	free_ins(macro);
 	free_array(&macro->env);

--- a/src/free_strings.c
+++ b/src/free_strings.c
@@ -6,13 +6,13 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/29 13:22:21 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/08/31 14:35:01 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/31 15:52:26 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-void	free_2_strings(char **str1, char **str2)
+char	*free_2_strings(char **str1, char **str2)
 {
 	if (str1 != NULL && *str1 != NULL)
 	{
@@ -24,14 +24,15 @@ void	free_2_strings(char **str1, char **str2)
 		free(*str2);
 		*str2 = NULL;
 	}
+	return(NULL);
 }
 
-void	free_array(char ***array)
+char	*free_array(char ***array)
 {
 	size_t	i;
 
 	if (*array == NULL)
-		return ;
+		return(NULL);
 	i = 0;
 	while ((*array)[i] != NULL)
 	{
@@ -41,6 +42,7 @@ void	free_array(char ***array)
 	}
 	free(*array);
 	*array = NULL;
+	return(NULL);
 }
 
 char	*free_string(char **str)

--- a/src/free_strings.c
+++ b/src/free_strings.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   free_strings.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/29 13:22:21 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/08/29 13:23:06 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/08/31 14:35:01 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,11 +43,12 @@ void	free_array(char ***array)
 	*array = NULL;
 }
 
-void	free_string(char **str)
+char	*free_string(char **str)
 {
 	if (str != NULL && *str != NULL)
 	{
 		free(*str);
 		*str = NULL;
 	}
+	return(NULL);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/02 14:49:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/30 15:18:48 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/31 15:40:49 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,104 +14,79 @@
 
 int			g_exit;
 
-int main(int argc, char **argv, char **envp)
+static char	*read_line(t_macro *macro)
 {
-    t_macro *macro;
-    char *line;
-    char *path;
+	char	*line;
+	char	*path;
 
-    g_exit = 0;
-    macro = init_macro(envp, argv);
-    signal(SIGINT, ft_signal_handler);
-    signal(SIGQUIT, SIG_IGN);
+	if (g_exit == 130)
+		line = readline("");
+	else
+	{
+		path = create_path(macro);
+		line = readline(path);
+		free(path);
+	}
+	return (line);
+}
 
-    if (argc == 3 && strcmp(argv[1], "-c") == 0)
-    {
-        // Handle command passed via -c option
-        line = argv[2];
+static int	evaluate_line(char *line, t_macro *macro)
+{
+	if (line == NULL || *line == EOF)
+	{
+		printf("exit\n");
+		return (-1);
+	}
+	if (ft_str_empty(line))
+		return (1);
+	if (line[0] != '\0')
+		add_history(line);
+	if (syntax_error_check(macro, line))
+		return (1);
+	if (g_exit > 0)
+	{
+		macro->exit_code = g_exit;
+		g_exit = 0;
+	}
+	macro->instruction = line;
+	return (0);
+}
 
-        if (line && !ft_str_empty(line))
-        {
-            macro->instruction = line;
-            tokenizer(macro);
-            parsing(macro);
-            if (macro->cmds)
-            {
-                execution(macro);
-                free_ins(macro);
-            }
-        }
+static void	execute_commands(t_macro *macro)
+{
+	if(tokenizer(macro) == -1)
+		return;
+	if(parsing(macro) == -1)
+		return;
+	execution(macro);
+	free_ins(macro);
+}
 
-        free_macro(macro);
-        exit(0);
-    }
+int	main(int argc, char **argv, char **envp)
+{
+	t_macro	*macro;
+	char	*line;
+	int		status;
 
-    while (1)
-    {
-        if (isatty(fileno(stdin)))
-        {
-            if (g_exit == 130)
-                line = readline("");
-            else
-            { 
-                path = create_path(macro);
-                line = readline(path);
-                free(path);
-            }
-        }
-        else
-        {
-            line = get_next_line(fileno(stdin));
-            if (line)
-            {
-                char *trimmed_line = ft_strtrim(line, "\n");
-                free(line);
-                line = trimmed_line;
-            }
-        }
-
-        if (line == NULL || *line == EOF)
-        {
-            g_exit = 0;
-            break;
-        }
-
-        if (ft_str_empty(line))
-        {
-            free(line);
-            continue;
-        }
-
-        if (line[0] != '\0')
-            add_history(line);
-
-        if (syntax_error_check(macro, line))
-        {
-            macro->exit_code = 2;
-            free(line);
-            continue;
-        }
-
-        if (g_exit > 0)
-        {
-            macro->exit_code = g_exit;
-            g_exit = 0;
-        }
-
-        macro->instruction = line;
-        tokenizer(macro);
-        parsing(macro);
-        if (macro->cmds == NULL)
-        {
-            free(line);
-            continue;
-        }
-
-        execution(macro);
-        free_ins(macro);
-    }
-
-    free_macro(macro);
-    exit(0);
+	(void)argc;
+	g_exit = 0;
+	macro = init_macro(envp, argv);
+	signal(SIGINT, ft_signal_handler);
+	signal(SIGQUIT, SIG_IGN);
+	while (1)
+	{
+		line = read_line(macro);
+		status = evaluate_line(line, macro);
+		if (status == -1)
+			break ;
+		else if (status == 1)
+		{
+			free_string(&line);
+			continue ;
+		}
+		execute_commands(macro);
+	}
+	free_macro(macro);
+	exit(0);
 }
 

--- a/src/split_args.c
+++ b/src/split_args.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/21 18:47:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/31 12:46:39 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/31 15:24:20 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -119,6 +119,5 @@ t_list	*split_args_by_quotes(char *ins)
 			}
 		}
 	}
-	free_string(&ins);
 	return (lexemes);
 }

--- a/src/split_args.c
+++ b/src/split_args.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/21 18:47:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 15:41:55 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/31 12:46:39 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -119,5 +119,6 @@ t_list	*split_args_by_quotes(char *ins)
 			}
 		}
 	}
+	free_string(&ins);
 	return (lexemes);
 }

--- a/src/tokenizer_expand.c
+++ b/src/tokenizer_expand.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/22 17:45:23 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/30 14:20:22 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/31 14:49:35 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,7 +37,7 @@ static t_token	*build_retokens(t_list *lexemes, t_type type)
 	return (retokens);
 }
 
-static void	plug_retokens(t_token *token, t_token *retokens, t_macro *macro)
+static t_token	*plug_retokens(t_token *token, t_token *retokens, t_macro *macro)
 {
 	t_token	*next;
 	t_token	*prev;
@@ -54,19 +54,17 @@ static void	plug_retokens(t_token *token, t_token *retokens, t_macro *macro)
 	last = last_token(retokens);
 	if (last)
 		last->next = next;
+	token->next = NULL;
+	free_tokens(&token);
+	return last;
 }
 
-static t_token	*retokenize(t_token *token, t_macro *macro)
+static t_token	*retokenize(char *expanded, t_token *token)
 {
 	t_list	*lexemes;
 	t_token	*retokens;
-	char	*expanded;
 
-	expanded = get_expanded_instruction(token->value, macro);
-	if (!expanded)
-		return (NULL);
 	lexemes = split_args_by_quotes(expanded);
-	free(expanded);
 	if (!lexemes)
 		return (NULL);
 	retokens = build_retokens(lexemes, token->type);
@@ -79,6 +77,7 @@ t_token	*expand_arg_tokens(t_macro *macro)
 {
 	t_token	*tokens;
 	t_token	*retokens;
+	t_token *last_retokens;
 	char	*expanded;
 
 	tokens = macro->tokens;
@@ -96,10 +95,11 @@ t_token	*expand_arg_tokens(t_macro *macro)
 			}
 			else
 			{
-				retokens = retokenize(tokens, macro);
+				retokens = retokenize(expanded, tokens);
 				if (!retokens)
 					return (NULL);
-				plug_retokens(tokens, retokens, macro);
+				last_retokens = plug_retokens(tokens, retokens, macro);
+				tokens = last_retokens;
 			}
 		}
 		tokens = tokens->next;
@@ -125,7 +125,7 @@ t_token	*remove_empty_envir_tokens(t_macro *macro)
 			}
 			if (*expanded == '\0')
 				remove_token(&macro->tokens, tokens);
-			free(expanded);
+			free_string(&expanded);
 		}
 		tokens = tokens->next;
 	}

--- a/src/tokenizer_expand.c
+++ b/src/tokenizer_expand.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/22 17:45:23 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/31 14:49:35 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/08/31 15:37:02 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,9 @@ static t_token	*build_retokens(t_list *lexemes, t_type type)
 		}
 		else
 			token->type = ARG;
-		token->value = lexemes->content;
+		token->value = ft_strdup(lexemes->content);
+		if(!token->value)
+			return(free_tokens(&token));
 		token_add_back(&retokens, token);
 		lexemes = lexemes->next;
 	}
@@ -70,6 +72,7 @@ static t_token	*retokenize(char *expanded, t_token *token)
 	retokens = build_retokens(lexemes, token->type);
 	if (!retokens)
 		return (NULL);
+	ft_lstclear(&lexemes, ft_del);
 	return (retokens);
 }
 
@@ -91,7 +94,7 @@ t_token	*expand_arg_tokens(t_macro *macro)
 			if (ft_strchr("\"", tokens->value[0]))
 			{
 				free_string(&tokens->value);
-				tokens->value = expanded;
+				tokens->value = ft_strdup(expanded);
 			}
 			else
 			{
@@ -101,6 +104,7 @@ t_token	*expand_arg_tokens(t_macro *macro)
 				last_retokens = plug_retokens(tokens, retokens, macro);
 				tokens = last_retokens;
 			}
+			free_string(&expanded);
 		}
 		tokens = tokens->next;
 	}


### PR DESCRIPTION
This update changes major things

- Expand envir variables is recursive now. If a `$VAR` envir has inside more envirs, it will keep expanding until there is none, like bash does.
- Retokenizer module rebuild the original tokens and plug the retokens into the original tokens like before, but now the retokens are skiped in the next steps, as they have been already evaluated
- All leaks related to expansion and retokenization have been fixed
- Free functions now return NULL. Use them like this to save save lines:
```
#new way
if(!line)
      return(free_string(&line));

#old way
if(!line)
{
     free_string(&line);
     return (NULL);
}
```