### PR TITLE
feat: strjoin with free mode

### DIFF
--- a/lib/libft/ft_strjoin.c
+++ b/lib/libft/ft_strjoin.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/25 17:17:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/03 09:21:54 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 10:36:20 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,13 +17,13 @@ static void free_arg_str(char **s1, char **s2, int mode)
 	if(mode == 0)
 		return;
 	else if(mode == 1)
-		ft_free((void **)&s1);
+		ft_free((void **)s1);
 	else if(mode == 2)
-		ft_free((void **)&s2);
+		ft_free((void **)s2);
 	else if(mode == 3)
 	{
-		ft_free((void **)&s1);
-		ft_free((void **)&s2);
+		ft_free((void **)s1);
+		ft_free((void **)s2);
 	}
 }
 

--- a/lib/libft/ft_strjoin.c
+++ b/lib/libft/ft_strjoin.c
@@ -6,13 +6,13 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/25 17:17:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/03 09:13:33 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 09:21:54 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-static void free_arg_str(char *s1, char *s2, int mode)
+static void free_arg_str(char **s1, char **s2, int mode)
 {
 	if(mode == 0)
 		return;
@@ -46,6 +46,6 @@ char	*ft_strjoin(char *s1, char *s2, char *delim, int mode)
 	if (delim)
 		res = ft_strcat(res, delim);
 	res = ft_strcat(res, s2);
-	free_arg_str(s1, s2, mode);
+	free_arg_str(&s1, &s2, mode);
 	return (res);
 }

--- a/lib/libft/ft_strjoin.c
+++ b/lib/libft/ft_strjoin.c
@@ -6,13 +6,28 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/25 17:17:38 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/06/17 14:40:40 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 09:13:33 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-char	*ft_strjoin(char const *s1, char const *s2, char *delim)
+static void free_arg_str(char *s1, char *s2, int mode)
+{
+	if(mode == 0)
+		return;
+	else if(mode == 1)
+		ft_free((void **)&s1);
+	else if(mode == 2)
+		ft_free((void **)&s2);
+	else if(mode == 3)
+	{
+		ft_free((void **)&s1);
+		ft_free((void **)&s2);
+	}
+}
+
+char	*ft_strjoin(char *s1, char *s2, char *delim, int mode)
 {
 	int		total_len;
 	char	*res;
@@ -31,5 +46,6 @@ char	*ft_strjoin(char const *s1, char const *s2, char *delim)
 	if (delim)
 		res = ft_strcat(res, delim);
 	res = ft_strcat(res, s2);
+	free_arg_str(s1, s2, mode);
 	return (res);
 }

--- a/lib/libft/libft.h
+++ b/lib/libft/libft.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/24 12:08:37 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/08/29 20:43:18 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 09:12:32 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -92,7 +92,7 @@ t_list				*ft_lstmap(t_list *lst, void *(*f)(void *),
 
 char				*ft_strcpy(char *dest, const char *src);
 char				*ft_strcat(char *dest, const char *src);
-char				*ft_strjoin(char const *s1, char const *s2, char *delim);
+char				*ft_strjoin(char *s1, char *s2, char *delim, int mode);
 int					ft_str_empty(char *str);
 char				*ft_strncpy(char *dest, const char *src, size_t n);
 

--- a/src/buin_cd.c
+++ b/src/buin_cd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   buin_cd.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/27 09:04:29 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/08/29 23:51:12 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/09/03 09:30:13 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,7 +45,7 @@ int	ft_cd2(char **args, t_macro *macro)
 		return (1);
 	if (change_directory(path, home) != 0)
 		return (1);
-	oldpwd = ft_strjoin(macro->m_pwd, "/", NULL);
+	oldpwd = ft_strjoin(macro->m_pwd, "/", NULL, 0);
 	update_environment(macro, oldpwd, path);
 	free_2_strings(&home, &oldpwd);
 	free(path);

--- a/src/buin_cd_utils.c
+++ b/src/buin_cd_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   buin_cd_utils.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/29 13:15:25 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/08/29 23:54:48 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/09/03 09:31:42 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,7 @@ char	*parse_arguments(char **args, t_macro *macro, char *home)
 	else if (ft_strncmp(args[1], "~", 1) == 0 && args[1][1] == '\0')
 		path = ft_strdup(macro->m_home);
 	else if (ft_strncmp(args[1], "~/", 2) == 0)
-		path = ft_strjoin(macro->m_home, args[1] + 1, NULL);
+		path = ft_strjoin(macro->m_home, args[1] + 1, NULL, 0);
 	else if (ft_strncmp(args[1], "-", 1) == 0)
 	{
 		path = grab_env("OLDPWD", macro->env, 6);
@@ -60,10 +60,9 @@ int	change_directory(char *path, char *home)
 	}
 	if (access(path, X_OK) != 0)
 	{
-		path = ft_strjoin("minishell: cd: ", path, NULL);
+		path = ft_strjoin("minishell: cd: ", path, NULL, 2);
 		perror(path);
 		free(home);
-		free(path);
 		return (1);
 	}
 	if (chdir(path) == -1)
@@ -99,7 +98,7 @@ void	update_environment(t_macro *macro, char *oldpwd, char *path)
 		ft_putstr_fd("cd: error retrieving current directory:", STDERR_FILENO);
 		ft_putstr_fd(" getcwd: cannot access parent ", STDERR_FILENO);
 		ft_putendl_fd("directories: No such file or directory", STDERR_FILENO);
-		macro->m_pwd = ft_strjoin(oldpwd, path, NULL);
+		macro->m_pwd = ft_strjoin(oldpwd, path, NULL, 0);
 		check_save_env("PWD", macro, 3);
 		return ;
 	}

--- a/src/buin_env.c
+++ b/src/buin_env.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   buin_env.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/27 09:04:37 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/08/28 02:09:57 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/09/03 09:27:09 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,8 +37,8 @@ char	**fix_env(char *var, char *value, char **env, int n)
 	char	*aux[2];
 
 	i[0] = -1;
-	aux[0] = ft_strjoin(var, "=", NULL);
-	aux[1] = ft_strjoin(aux[0], value, NULL);
+	aux[0] = ft_strjoin(var, "=", NULL, 0);
+	aux[1] = ft_strjoin(aux[0], value, NULL, 0);
 	free(aux[0]);
 	while (!ft_strchr(var, '=') && env && env[++i[0]])
 	{

--- a/src/env.c
+++ b/src/env.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/07 09:11:22 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/08/30 10:03:08 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/09/03 09:28:24 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,8 +55,8 @@ void	ft_export_do(t_macro *macro, char *name, char *value)
 	int		pos;
 	char	*cmd;
 
-	cmd = ft_strjoin(name, "=", 0);
-	cmd = ft_strjoin(cmd, value, 0);
+	cmd = ft_strjoin(name, "=", 0, 0);
+	cmd = ft_strjoin(cmd, value, 0, 0);
 	ij[0] = 1;
 	pos = var_in_env(cmd, macro->env, ij);
 	if (pos == 1)

--- a/src/expand.c
+++ b/src/expand.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/21 18:52:58 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/01 21:53:23 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 09:25:34 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,10 +19,7 @@ void	handle_normal_char(char **clean, char *ins, size_t *i)
 
 	str[0] = ins[*i];
 	str[1] = '\0';
-	temp = ft_strjoin(*clean, str, NULL);
-	if (!temp)
-		return (free(*clean));
-	free_string(clean);
+	temp = ft_strjoin(*clean, str, NULL, 1);
 	*clean = temp;
 	(*i)++;
 }
@@ -44,12 +41,7 @@ void	handle_envir(char **clean, char *ins, size_t *i, t_macro *macro)
 	envir_value = ft_getenv(envir_name, macro->env);
 	free_string(&envir_name);
 	if (envir_value)
-	{
-		*clean = ft_strjoin(*clean, envir_value, NULL);
-		if (!*clean)
-			return (free(*clean));
-	}
-	free_string(&envir_value);
+		*clean = ft_strjoin(*clean, envir_value, NULL, 3);
 	*i = start;
 }
 
@@ -74,9 +66,12 @@ void	handle_quoted_literal(char **clean, char *ins, size_t *i)
 		*i += ft_strlen(&ins[*i]);
 	}
 	if (!temp)
-		return (free(*clean));
-	*clean = ft_strjoin(*clean, temp, NULL);
-	free_string(&temp);
+	{
+		free(*clean);
+		*clean = NULL;
+		return;
+	}
+	*clean = ft_strjoin(*clean, temp, NULL, 3);
 }
 
 void	handle_exit_code(char **clean, size_t *i, t_macro *macro)
@@ -87,13 +82,10 @@ void	handle_exit_code(char **clean, size_t *i, t_macro *macro)
 	substr = ft_itoa(macro->exit_code);
 	if (!substr)
 		free_string(clean);
-	temp = ft_strjoin(*clean, substr, NULL);
+	temp = ft_strjoin(*clean, substr, NULL, 3);
 	if (!temp)
-		return (free(*clean));
-	free_string(clean);
-	*clean = temp;
+		return ;
 	*i += 2;
-	free_string(&substr);
 }
 
 char	*get_expanded_ins(char *ins, t_macro *macro)

--- a/src/expand_utils.c
+++ b/src/expand_utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/22 20:53:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/01 21:47:26 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 09:29:49 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,10 +66,9 @@ void	handle_delimiter_after_dollar(char **clean, char *ins, size_t *i)
 
 	str[0] = ins[*i];
 	str[1] = '\0';
-	temp = ft_strjoin(*clean, str, NULL);
+	temp = ft_strjoin(*clean, str, NULL, 1);
 	if (!temp)
-		return (free(*clean));
-	free_string(clean);
+		return ;
 	*clean = temp;
 	(*i)++;
 }
@@ -81,10 +80,9 @@ void	handle_unexpected_case(char **clean, char *ins, size_t *i)
 
 	str[0] = ins[*i];
 	str[1] = '\0';
-	temp = ft_strjoin(*clean, str, NULL);
+	temp = ft_strjoin(*clean, str, NULL, 1);
 	if (!temp)
-		return (free(*clean));
-	free_string(clean);
+		return ;
 	*clean = temp;
 	(*i)++;
 }

--- a/src/validation_utils.c
+++ b/src/validation_utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/13 23:25:19 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/01 12:51:38 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 09:28:57 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -78,7 +78,7 @@ char	*get_executable_path(char **paths, char *executable, t_macro *macro)
 	i = 0;
 	while (paths[i])
 	{
-		full_path = ft_strjoin(paths[i], executable, "/");
+		full_path = ft_strjoin(paths[i], executable, "/", 0);
 		if (full_path == NULL)
 			return (NULL);
 		if (!access(full_path, F_OK))


### PR DESCRIPTION
ft_strjoin is modified so it can optionally free the arguments strings before returning the new allocated string.

Modes are:

- 0: don't free anything
- 1: free s1
- 2: free s2
- 3: free s1 and s2

NB: I've adapted the code everywhere that the strjoin is called. I've added a mode = 0 in all your functions, unless was very clear that any of the strings must be freed later. 

There are some double frees now in expand module, but this will be addressed in a new PR.