### PR TITLE
feat: Fix small leak when evaluating for empty expansions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+local.supp

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/03 15:03:39 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 17:04:43 by dbejar-s         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,9 +83,7 @@ typedef struct s_cmd
 
 typedef struct s_macro
 {
-	char			**envp;
 	char			**env;
-	char			**history;
 	char			*ins;
 	t_token			*tokens;
 	t_cmd			*cmds;
@@ -213,7 +211,7 @@ t_macro				*start_env(t_macro *macro, char **argv);
 char				*ft_getenv(char *var, char **env);
 int					ft_pwd2(t_macro *macro);
 int					ft_env2(t_macro *macro);
-int					ft_exit2(char **args);
+int					ft_exit2(char **args, t_macro *macro);
 int					ft_unset2(char **args, t_macro *macro);
 int					ft_export2(char **args, t_macro *macro);
 int					ft_echo2(char **args);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -6,7 +6,7 @@
 /*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/09 15:55:31 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/08/28 02:09:43 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/09/03 17:04:14 by dbejar-s         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,6 +27,6 @@ int	select_and_run_builtin(char *cmd, char **args, t_macro *macro)
 	if (ft_strncmp(cmd, "env", 3) == 0)
 		return (ft_env2(macro));
 	if (ft_strncmp(cmd, "exit", 4) == 0)
-		return (ft_exit2(args));
+		return (ft_exit2(args, macro));
 	return (0);
 }

--- a/src/buin_exit.c
+++ b/src/buin_exit.c
@@ -6,7 +6,7 @@
 /*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/27 09:04:40 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/09/02 15:50:59 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/09/03 17:11:15 by dbejar-s         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,7 +31,7 @@ static int	validate_numeric_argument(char *arg)
 	return (0);
 }
 
-int	ft_exit2(char **args)
+int	ft_exit2(char **args, t_macro *macro)
 {
 	int	argc;
 	int	code;
@@ -43,19 +43,25 @@ int	ft_exit2(char **args)
 	if (argc == 1)
 	{
 		ft_putstr_fd("exit\n", STDOUT_FILENO);
+		free_macro(macro);
 		exit(0);
 	}
 	if (argc > 2)
 	{
 		ft_putendl_fd("minishell: exit: too many arguments", STDERR_FILENO);
+		free_macro(macro);
 		exit(1);
 	}
 	validation_result = validate_numeric_argument(args[1]);
 	if (validation_result != 0)
+	{
+		free_macro(macro);
 		exit(validation_result);
+	}
 	code = ft_atoi(args[1]);
 	if (code > 255 || code < 0)
 		code = code % 256;
 	ft_putstr_fd("exit\n", STDOUT_FILENO);
+	free_macro(macro);
 	exit(code);
 }

--- a/src/free.c
+++ b/src/free.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   free.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/04 13:02:09 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/01 13:52:46 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 16:57:49 by dbejar-s         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,7 +61,6 @@ t_macro	*free_macro(t_macro *macro)
 {
 	free_ins(macro);
 	free_array(&macro->env);
-	free_array(&macro->history);
 	free_string(&macro->ins);
 	free_string(&macro->m_pwd);
 	free_string(&macro->m_home);

--- a/src/general_utils.c
+++ b/src/general_utils.c
@@ -6,7 +6,7 @@
 /*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/29 13:43:00 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/09/02 12:58:20 by dbejar-s         ###   ########.fr       */
+/*   Updated: 2024/09/03 17:01:53 by dbejar-s         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,16 +74,13 @@ t_macro	*init_macro(char **envp, char **argv)
 {
 	t_macro	*macro;
 
-	macro = malloc(sizeof(t_macro));
+	macro = ft_calloc(sizeof(t_macro), 1);
 	if (!macro)
 	{
 		ft_putstr_fd("Error: Malloc failed creating macro structure\n", 2);
 		exit(1);
 	}
-	ft_bzero(macro, sizeof(t_macro));
-	macro->envp = envp;
 	macro->env = copy_env(envp);
-	macro->history = NULL;
 	macro->ins = NULL;
 	macro->tokens = NULL;
 	macro->cmds = NULL;


### PR DESCRIPTION
The recent code changes address a small leak that occurs when evaluating for empty expansions. The changes include modifications to the `.gitignore` file and updates to the `minishell.h`, `builtins.c`, `buin_exit.c`, `free.c`, and `general_utils.c` files.

Based on the recent user commits and repository commits, the suggested commit message is "feat: Fix small leak when evaluating for empty expansions".