### PR TITLE
Fix/more quotes handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/08/01 15:11:43 by pmarkaid          #+#    #+#              #
-#    Updated: 2024/09/02 21:59:26 by pmarkaid         ###   ########.fr        #
+#    Updated: 2024/09/03 23:38:53 by pmarkaid         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -34,6 +34,7 @@ SRCS_FILES = \
 	dup.c \
 	expand.c \
 	expand_utils.c \
+	expand_cases.c \
 	split_args.c \
 	buin_cd.c \
 	buin_echo.c \

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/03 23:05:36 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 23:38:24 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -237,6 +237,12 @@ char				*upper_than_home(t_macro *macro);
 char				*create_path(t_macro *macro);
 int					validate_and_clean_argument(char *arg, int *exit_flag);
 bool 				inside_double_quotes(const char *str, int index);
+
+void	handle_normal_char(char **clean, char *ins, size_t *i);
+void	handle_quoted_literal(char **clean, char *ins, size_t *i);
+void	handle_delimiter_after_dollar(char **clean, char *ins, size_t *i);
+void	handle_unexpected_case(char **clean, char *ins, size_t *i);
+
 
 /* error */
 int					error_msg(t_macro *macro, char *msg, int exit_code);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+        */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/01 15:11:45 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/03 15:59:58 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 23:05:36 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -236,6 +236,7 @@ int					in_home(t_macro *macro);
 char				*upper_than_home(t_macro *macro);
 char				*create_path(t_macro *macro);
 int					validate_and_clean_argument(char *arg, int *exit_flag);
+bool 				inside_double_quotes(const char *str, int index);
 
 /* error */
 int					error_msg(t_macro *macro, char *msg, int exit_code);

--- a/src/expand.c
+++ b/src/expand.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/21 18:52:58 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/03 17:15:54 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 23:08:51 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,7 +66,6 @@ void	handle_quoted_literal(char **clean, char *ins, size_t *i)
 	if (!temp)
 	{
 		free(*clean);
-		*clean = NULL;
 		return ;
 	}
 	*clean = ft_strjoin(*clean, temp, NULL, 3);
@@ -98,7 +97,9 @@ char	*get_expanded_ins(char *ins, t_macro *macro)
 			handle_normal_char(&clean, ins, &i);
 		else if (ins[i] == '$' && ins[i + 1] == '?')
 			handle_exit_code(&clean, &i, macro);
-		else if (ins[i] == '$' && (ins[i + 1] == '\'' || ins[i + 1] == '\"'))
+		else if (ins[i] == '$' && ft_isquote(ins[i + 1]) && !inside_double_quotes(ins, i))
+			i++;
+		else if (ins[i] == '$' && ft_isquote(ins[i + 1]) && inside_double_quotes(ins, i))
 			handle_quoted_literal(&clean, ins, &i);
 		else if (ins[i] == '$' && ft_isdelim(ins[i + 1]))
 			handle_delimiter_after_dollar(&clean, ins, &i);

--- a/src/expand.c
+++ b/src/expand.c
@@ -6,21 +6,11 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/21 18:52:58 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/03 23:08:51 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 23:28:57 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-
-void	handle_normal_char(char **clean, char *ins, size_t *i)
-{
-	char	str[2];
-
-	str[0] = ins[*i];
-	str[1] = '\0';
-	*clean = ft_strjoin(*clean, str, NULL, 1);
-	(*i)++;
-}
 
 void	handle_envir(char **clean, char *ins, size_t *i, t_macro *macro)
 {
@@ -43,34 +33,6 @@ void	handle_envir(char **clean, char *ins, size_t *i, t_macro *macro)
 	*i = start;
 }
 
-void	handle_quoted_literal(char **clean, char *ins, size_t *i)
-{
-	char	quote_char;
-	char	*quote_start;
-	char	*quote_end;
-	char	*temp;
-
-	quote_char = ins[*i + 1];
-	quote_start = &ins[*i + 2];
-	quote_end = ft_strchr(quote_start, quote_char);
-	if (quote_end)
-	{
-		temp = ft_substr(ins, *i, quote_end - quote_start + 3);
-		*i += (quote_end - quote_start) + 3;
-	}
-	else
-	{
-		temp = ft_strdup(&ins[*i]);
-		*i += ft_strlen(&ins[*i]);
-	}
-	if (!temp)
-	{
-		free(*clean);
-		return ;
-	}
-	*clean = ft_strjoin(*clean, temp, NULL, 3);
-}
-
 void	handle_exit_code(char **clean, size_t *i, t_macro *macro)
 {
 	char	*substr;
@@ -80,6 +42,31 @@ void	handle_exit_code(char **clean, size_t *i, t_macro *macro)
 		free_string(clean);
 	*clean = ft_strjoin(*clean, substr, NULL, 3);
 	*i += 2;
+}
+
+static void	literal_cases(char **clean, char *ins, size_t *i)
+{
+	if (ins[*i] != '$' || !envir_must_be_expanded(ins, *i))
+		handle_normal_char(clean, ins, i);
+	else if (ins[*i] == '$' && ft_isquote(ins[*i + 1]))
+	{
+		if (inside_double_quotes(ins, *i))
+			handle_quoted_literal(clean, ins, i);
+		else
+			(*i)++;
+	}
+	else if (ins[*i] == '$' && ft_isdelim(ins[*i + 1]))
+		handle_delimiter_after_dollar(clean, ins, i);
+}
+
+static void	dollar_cases(char **clean, char *ins, size_t *i, t_macro *macro)
+{
+	if (ins[*i] == '$' && ins[*i + 1] == '?')
+		handle_exit_code(clean, i, macro);
+	else if (ins[*i] == '$' && (ft_isalnum(ins[*i + 1]) || ins[*i + 1] == '_'))
+		handle_envir(clean, ins, i, macro);
+	else
+		handle_unexpected_case(clean, ins, i);
 }
 
 char	*get_expanded_ins(char *ins, t_macro *macro)
@@ -93,20 +80,10 @@ char	*get_expanded_ins(char *ins, t_macro *macro)
 	i = 0;
 	while (ins[i])
 	{
-		if (ins[i] != '$' || !envir_must_be_expanded(ins, i))
-			handle_normal_char(&clean, ins, &i);
-		else if (ins[i] == '$' && ins[i + 1] == '?')
-			handle_exit_code(&clean, &i, macro);
-		else if (ins[i] == '$' && ft_isquote(ins[i + 1]) && !inside_double_quotes(ins, i))
-			i++;
-		else if (ins[i] == '$' && ft_isquote(ins[i + 1]) && inside_double_quotes(ins, i))
-			handle_quoted_literal(&clean, ins, &i);
-		else if (ins[i] == '$' && ft_isdelim(ins[i + 1]))
-			handle_delimiter_after_dollar(&clean, ins, &i);
-		else if (ins[i] == '$' && (ft_isalnum(ins[i + 1]) || ins[i + 1] == '_'))
-			handle_envir(&clean, ins, &i, macro);
-		else
-			handle_unexpected_case(&clean, ins, &i);
+		literal_cases(&clean, ins, &i);
+		if (!clean)
+			return (NULL);
+		dollar_cases(&clean, ins, &i, macro);
 		if (!clean)
 			return (NULL);
 	}

--- a/src/expand.c
+++ b/src/expand.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/21 18:52:58 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/03 23:28:57 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 23:46:06 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,10 +44,12 @@ void	handle_exit_code(char **clean, size_t *i, t_macro *macro)
 	*i += 2;
 }
 
-static void	literal_cases(char **clean, char *ins, size_t *i)
+static void	handle_cases(char **clean, char *ins, size_t *i, t_macro *macro)
 {
 	if (ins[*i] != '$' || !envir_must_be_expanded(ins, *i))
 		handle_normal_char(clean, ins, i);
+	else if (ins[*i] == '$' && ins[*i + 1] == '?')
+		handle_exit_code(clean, i, macro);
 	else if (ins[*i] == '$' && ft_isquote(ins[*i + 1]))
 	{
 		if (inside_double_quotes(ins, *i))
@@ -57,12 +59,6 @@ static void	literal_cases(char **clean, char *ins, size_t *i)
 	}
 	else if (ins[*i] == '$' && ft_isdelim(ins[*i + 1]))
 		handle_delimiter_after_dollar(clean, ins, i);
-}
-
-static void	dollar_cases(char **clean, char *ins, size_t *i, t_macro *macro)
-{
-	if (ins[*i] == '$' && ins[*i + 1] == '?')
-		handle_exit_code(clean, i, macro);
 	else if (ins[*i] == '$' && (ft_isalnum(ins[*i + 1]) || ins[*i + 1] == '_'))
 		handle_envir(clean, ins, i, macro);
 	else
@@ -80,10 +76,7 @@ char	*get_expanded_ins(char *ins, t_macro *macro)
 	i = 0;
 	while (ins[i])
 	{
-		literal_cases(&clean, ins, &i);
-		if (!clean)
-			return (NULL);
-		dollar_cases(&clean, ins, &i, macro);
+		handle_cases(&clean, ins, &i, macro);
 		if (!clean)
 			return (NULL);
 	}

--- a/src/expand_cases.c
+++ b/src/expand_cases.c
@@ -1,0 +1,79 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expand_cases.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/09/03 23:27:34 by pmarkaid          #+#    #+#             */
+/*   Updated: 2024/09/03 23:30:51 by pmarkaid         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+void	handle_normal_char(char **clean, char *ins, size_t *i)
+{
+	char	str[2];
+
+	str[0] = ins[*i];
+	str[1] = '\0';
+	*clean = ft_strjoin(*clean, str, NULL, 1);
+	(*i)++;
+}
+
+void	handle_quoted_literal(char **clean, char *ins, size_t *i)
+{
+	char	quote_char;
+	char	*quote_start;
+	char	*quote_end;
+	char	*temp;
+
+	quote_char = ins[*i + 1];
+	quote_start = &ins[*i + 2];
+	quote_end = ft_strchr(quote_start, quote_char);
+	if (quote_end)
+	{
+		temp = ft_substr(ins, *i, quote_end - quote_start + 3);
+		*i += (quote_end - quote_start) + 3;
+	}
+	else
+	{
+		temp = ft_strdup(&ins[*i]);
+		*i += ft_strlen(&ins[*i]);
+	}
+	if (!temp)
+	{
+		free(*clean);
+		return ;
+	}
+	*clean = ft_strjoin(*clean, temp, NULL, 3);
+}
+
+void	handle_delimiter_after_dollar(char **clean, char *ins, size_t *i)
+{
+	char	str[2];
+	char	*temp;
+
+	str[0] = ins[*i];
+	str[1] = '\0';
+	temp = ft_strjoin(*clean, str, NULL, 1);
+	if (!temp)
+		return ;
+	*clean = temp;
+	(*i)++;
+}
+
+void	handle_unexpected_case(char **clean, char *ins, size_t *i)
+{
+	char	str[2];
+	char	*temp;
+
+	str[0] = ins[*i];
+	str[1] = '\0';
+	temp = ft_strjoin(*clean, str, NULL, 1);
+	if (!temp)
+		return ;
+	*clean = temp;
+	(*i)++;
+}

--- a/src/expand_utils.c
+++ b/src/expand_utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/22 20:53:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/03 15:03:08 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 23:05:12 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,6 +64,22 @@ bool	is_in_quote(char *str, int index)
 	if (inside_single_quotes || inside_double_quotes)
 		return (true);
 	return (false);
+}
+
+bool inside_double_quotes(const char *str, int index) {
+    bool inside_double_quotes = false;
+    bool inside_single_quotes = false;
+    int i = 0;
+
+    while (i < index && str[i] != '\0') {
+        if (str[i] == '\"' && !inside_single_quotes) {
+            inside_double_quotes = !inside_double_quotes;
+        } else if (str[i] == '\'' && !inside_double_quotes) {
+            inside_single_quotes = !inside_single_quotes;
+        }
+        i++;
+    }
+    return inside_double_quotes;
 }
 
 void	handle_delimiter_after_dollar(char **clean, char *ins, size_t *i)

--- a/src/expand_utils.c
+++ b/src/expand_utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/22 20:53:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/03 23:05:12 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/03 23:31:06 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,46 +66,22 @@ bool	is_in_quote(char *str, int index)
 	return (false);
 }
 
-bool inside_double_quotes(const char *str, int index) {
-    bool inside_double_quotes = false;
-    bool inside_single_quotes = false;
-    int i = 0;
-
-    while (i < index && str[i] != '\0') {
-        if (str[i] == '\"' && !inside_single_quotes) {
-            inside_double_quotes = !inside_double_quotes;
-        } else if (str[i] == '\'' && !inside_double_quotes) {
-            inside_single_quotes = !inside_single_quotes;
-        }
-        i++;
-    }
-    return inside_double_quotes;
-}
-
-void	handle_delimiter_after_dollar(char **clean, char *ins, size_t *i)
+bool	inside_double_quotes(const char *str, int index)
 {
-	char	str[2];
-	char	*temp;
+	bool	inside_double_quotes;
+	bool	inside_single_quotes;
+	int		i;
 
-	str[0] = ins[*i];
-	str[1] = '\0';
-	temp = ft_strjoin(*clean, str, NULL, 1);
-	if (!temp)
-		return ;
-	*clean = temp;
-	(*i)++;
-}
-
-void	handle_unexpected_case(char **clean, char *ins, size_t *i)
-{
-	char	str[2];
-	char	*temp;
-
-	str[0] = ins[*i];
-	str[1] = '\0';
-	temp = ft_strjoin(*clean, str, NULL, 1);
-	if (!temp)
-		return ;
-	*clean = temp;
-	(*i)++;
+	inside_double_quotes = false;
+	inside_single_quotes = false;
+	i = 0;
+	while (i < index && str[i] != '\0')
+	{
+		if (str[i] == '\"' && !inside_single_quotes)
+			inside_double_quotes = !inside_double_quotes;
+		else if (str[i] == '\'' && !inside_double_quotes)
+			inside_single_quotes = !inside_single_quotes;
+		i++;
+	}
+	return (inside_double_quotes);
 }


### PR DESCRIPTION
This update fixes quotes in weird scenarios.

Situations like `$'HOME'$USER`, when the result shall be HOME(USERNAME), without the initial dollar. If the initial dollar is inside double quotes, must be preserved.

```
echo $'HOME'$USER
HOMEpeitx

echo "$'HOME'$USER"
$'HOME'peitx
```