### PR TITLE
fix: reset value of read_end in each iteration

### DIFF
--- a/src/dup.c
+++ b/src/dup.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/13 23:24:13 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/04 10:21:52 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/05 15:28:47 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -87,6 +87,8 @@ static int	dup_stdin(t_macro *macro, t_cmd *cmd)
 	{
 		if (dup2(macro->read_end, STDIN_FILENO) < 0)
 			return (-1);
+		close(macro->read_end);
+		macro->read_end = -1;
 	}
 	if (macro->pipe_fd[0] != -1)
 		close(macro->pipe_fd[0]);

--- a/src/execution.c
+++ b/src/execution.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:23:53 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/04 10:21:18 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/05 15:21:25 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -86,6 +86,7 @@ static int	execute_cmds(t_macro *macro)
 
 int	prepare_execution(t_macro *macro)
 {
+	macro->read_end = -1;
 	macro->pid = malloc(sizeof(pid_t) * macro->num_cmds);
 	if (macro->pid == NULL)
 	{

--- a/src/general_utils.c
+++ b/src/general_utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/29 13:43:00 by dbejar-s          #+#    #+#             */
-/*   Updated: 2024/09/04 11:57:49 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/05 15:19:24 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -93,5 +93,6 @@ t_macro	*init_macro(char **envp, char **argv)
 	macro->m_home = grab_home(macro);
 	macro->pipe_fd[0] = -1;
 	macro->pipe_fd[1] = -1;
+	macro->read_end = -1;
 	return (macro);
 }


### PR DESCRIPTION
This update fixes the errors we had when executing pipes, specifically when we executed the **second** piped instruction.

The error arises from now resetting the `read_end` file descriptor in each iteration of the execution module. Originally, it was reset to 0, but after moving `read_end` to the macro, was considered not necessary.

The fix corrects that and adds new security measures in case execve fails.