### PR TITLE
fix: clean ins in correct place

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: dbejar-s <dbejar-s@student.hive.fi>        +#+  +:+       +#+         #
+#    By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/08/01 15:11:43 by pmarkaid          #+#    #+#              #
-#    Updated: 2024/09/06 13:50:19 by dbejar-s         ###   ########.fr        #
+#    Updated: 2024/09/07 16:08:37 by pmarkaid         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -69,8 +69,8 @@ TEST_OBJS = $(TEST_SRCS:.c=.o)
 TEST_NAME = tests_runner
 
 CC = cc 
-CFLAGS = -Wall -Werror -Wextra  -g
-DEBUG_FLAGS = -Wall -Werror -Wextra -fsanitize=address -g
+CFLAGS = -Wall -Werror -Wextra -g
+DEBUG_FLAGS = -Wall -Werror -Wextra -fsanitize=address
 
 # External Libraries
 LIBS = -lreadline

--- a/src/free.c
+++ b/src/free.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/04 13:02:09 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/04 11:05:34 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/07 16:22:48 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,6 +49,7 @@ t_cmd	*free_cmds(t_cmd **cmds)
 
 t_macro	*free_ins(t_macro *macro)
 {
+	free_string(&macro->ins);
 	free_tokens(&macro->tokens);
 	free_cmds(&macro->cmds);
 	free(macro->pid);
@@ -61,7 +62,6 @@ t_macro	*free_macro(t_macro *macro)
 {
 	free_ins(macro);
 	free_array(&macro->env);
-	free_string(&macro->ins);
 	free_string(&macro->m_pwd);
 	free_string(&macro->m_home);
 	free(macro);

--- a/src/validation.c
+++ b/src/validation.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/08 22:35:57 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/07 15:46:19 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/07 16:24:13 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,7 +74,6 @@ void	search_executable(t_macro *macro, t_cmd *cmd)
 	{
 		ft_putstr_fd(exec, 2);
 		ft_putstr_fd(": command not found\n", 2);
-		macro->exit_code = 127;
 		free_macro(macro);
 		exit(127);
 	}


### PR DESCRIPTION
macro->ins now is freed inside free_ins function, not free_macro.

I detect a readline leak that was to consistent to be an readline error. I detected the instruction was not fixed in the proper function, so depend on the situations we can return with a free_ins without freeing the instruction, which make no sense.