### PR TITLE
fix: remove leading spaces before argument expansion

### DIFF
--- a/src/tokenizer_expand.c
+++ b/src/tokenizer_expand.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/22 17:45:23 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/03 15:25:25 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/08 12:46:02 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,6 +31,7 @@ t_token	*expand_token(t_token *token, t_macro *macro)
 	expanded = get_expanded_ins(token->value, macro);
 	if (!expanded || *expanded == '\0')
 		return (NULL);
+	fix_redirections(expanded);
 	if (ft_strchr("\"", token->value[0]))
 	{
 		token->value = handle_literal_string(token, expanded);


### PR DESCRIPTION
I fixed the error where our expansions don't work if they have a leading spaces adding the fix_retokenizer function. But this is not best approach as it bash preserves the space between redir char and filenames. Will fix more later

``` c
#bash
export A=" cat infile >   outfile"
$A
HELLO WORLD
cat: '>': No such file or directory
cat: outfile: No such file or directory

#minishell
export A=" cat infile >   outfile"
$A
HELLO WORLD
/usr/bin/cat: '>outfile': No such file or directory
```